### PR TITLE
Phase 2 graph foundation: Graph type, sample generators, typed registry

### DIFF
--- a/__tests__/lib/algorithms/graph/graph.test.ts
+++ b/__tests__/lib/algorithms/graph/graph.test.ts
@@ -3,9 +3,14 @@ import { dfs } from "@/lib/algorithms/graph/dfs";
 import { bfs } from "@/lib/algorithms/graph/bfs";
 import { dijkstra } from "@/lib/algorithms/graph/dijkstra";
 import { topologicalSort } from "@/lib/algorithms/graph/topologicalSort";
-import type { AlgorithmVisualization, GraphStep } from "@/lib/types";
+import {
+  sampleDAG,
+  sampleUndirectedGraph,
+  sampleWeightedGraph,
+} from "@/lib/algorithms/graph/sampleGraphs";
+import type { AlgorithmVisualization, Graph, GraphStep } from "@/lib/types";
 
-type GraphFn = (arr: number[], start?: number) => AlgorithmVisualization;
+type GraphFn = (graph: Graph, start?: number) => AlgorithmVisualization;
 
 const traversals: Array<{ name: string; key: string; fn: GraphFn }> = [
   { name: "dfs", key: "dfs", fn: dfs },
@@ -19,50 +24,55 @@ function lastStep(viz: AlgorithmVisualization): GraphStep {
 
 describe.each(traversals)("$name", ({ key, fn }) => {
   it("returns metadata", () => {
-    const viz = fn([], 0);
+    const viz = fn(sampleUndirectedGraph(), 0);
     expect(viz.key).toBe(key);
     expect(viz.category).toBe("graph");
     expect(viz.steps.length).toBeGreaterThan(0);
   });
 
   it("visits every reachable vertex from start vertex 0", () => {
-    const viz = fn([], 0);
+    const viz = fn(sampleUndirectedGraph(), 0);
     const final = lastStep(viz);
-    // The hardcoded graph in dfs/bfs has 6 fully connected vertices
     expect(final.visited.sort()).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
   it("clamps invalid start vertex to 0", () => {
-    const viz = fn([], 999);
+    const viz = fn(sampleUndirectedGraph(), 999);
     const final = lastStep(viz);
     expect(final.visited.length).toBeGreaterThan(0);
+  });
+
+  it("each step embeds the original graph", () => {
+    const viz = fn(sampleUndirectedGraph(), 0);
+    const step = lastStep(viz);
+    expect(step.graph.numVertices).toBe(6);
+    expect(step.graph.directed).toBe(false);
   });
 });
 
 describe("dijkstra", () => {
   it("returns metadata", () => {
-    const viz = dijkstra([], 0);
+    const viz = dijkstra(sampleWeightedGraph(), 0);
     expect(viz.key).toBe("dijkstra");
     expect(viz.category).toBe("graph");
     expect(viz.steps.length).toBeGreaterThan(0);
   });
 
   it("visits all 6 vertices in the predefined graph", () => {
-    const viz = dijkstra([], 0);
+    const viz = dijkstra(sampleWeightedGraph(), 0);
     const final = lastStep(viz);
     expect(final.visited.sort()).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
   it("starts from the given source", () => {
-    const viz = dijkstra([], 2);
+    const viz = dijkstra(sampleWeightedGraph(), 2);
     const steps = viz.steps as GraphStep[];
-    // First non-empty visited entry should include 2
     const firstVisit = steps.find((s) => s.visited.length > 0);
     expect(firstVisit?.visited).toContain(2);
   });
 
   it("clamps invalid source to 0", () => {
-    const viz = dijkstra([], -1);
+    const viz = dijkstra(sampleWeightedGraph(), -1);
     const final = lastStep(viz);
     expect(final.visited.length).toBe(6);
   });
@@ -70,24 +80,23 @@ describe("dijkstra", () => {
 
 describe("topologicalSort", () => {
   it("returns metadata", () => {
-    const viz = topologicalSort([]);
+    const viz = topologicalSort(sampleDAG());
     expect(viz.key).toBe("topologicalSort");
     expect(viz.category).toBe("graph");
     expect(viz.steps.length).toBeGreaterThan(0);
   });
 
   it("produces a valid ordering of all vertices", () => {
-    const viz = topologicalSort([]);
+    const viz = topologicalSort(sampleDAG());
     const final = lastStep(viz);
-    // The DAG has 6 vertices: 0 -> {1,2}, 1 -> 3, 2 -> {3,4}, 3 -> 5, 4 -> 5
     expect(final.stack.sort()).toEqual([0, 1, 2, 3, 4, 5]);
   });
 
   it("orders dependencies before dependents", () => {
-    const viz = topologicalSort([]);
+    const viz = topologicalSort(sampleDAG());
     const order = lastStep(viz).stack;
     const indexOf = (v: number) => order.indexOf(v);
-    // 0 must come before 1, 2; 1 before 3; 2 before 3, 4; 3 before 5; 4 before 5
+    // sampleDAG: 0->{1,2}, 1->3, 2->{3,4}, 3->5, 4->5
     expect(indexOf(0)).toBeLessThan(indexOf(1));
     expect(indexOf(0)).toBeLessThan(indexOf(2));
     expect(indexOf(1)).toBeLessThan(indexOf(3));
@@ -95,5 +104,11 @@ describe("topologicalSort", () => {
     expect(indexOf(2)).toBeLessThan(indexOf(4));
     expect(indexOf(3)).toBeLessThan(indexOf(5));
     expect(indexOf(4)).toBeLessThan(indexOf(5));
+  });
+
+  it("each step embeds the directed graph", () => {
+    const viz = topologicalSort(sampleDAG());
+    const step = lastStep(viz);
+    expect(step.graph.directed).toBe(true);
   });
 });

--- a/__tests__/lib/algorithms/graph/sampleGraphs.test.ts
+++ b/__tests__/lib/algorithms/graph/sampleGraphs.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import {
+  cloneGraph,
+  createGraph,
+  defaultGraphFor,
+  sampleDAG,
+  sampleUndirectedGraph,
+  sampleWeightedGraph,
+} from "@/lib/algorithms/graph/sampleGraphs";
+
+describe("createGraph", () => {
+  it("derives adjacency from edges for undirected graphs", () => {
+    const g = createGraph({
+      numVertices: 3,
+      directed: false,
+      edges: [
+        { from: 0, to: 1 },
+        { from: 1, to: 2 },
+      ],
+    });
+    expect(g.adjacency[0]!.map((e) => e.to)).toEqual([1]);
+    expect(g.adjacency[1]!.map((e) => e.to).sort()).toEqual([0, 2]);
+    expect(g.adjacency[2]!.map((e) => e.to)).toEqual([1]);
+  });
+
+  it("derives adjacency from edges for directed graphs", () => {
+    const g = createGraph({
+      numVertices: 3,
+      directed: true,
+      edges: [
+        { from: 0, to: 1 },
+        { from: 1, to: 2 },
+      ],
+    });
+    expect(g.adjacency[0]!.map((e) => e.to)).toEqual([1]);
+    expect(g.adjacency[1]!.map((e) => e.to)).toEqual([2]);
+    expect(g.adjacency[2]).toEqual([]);
+  });
+
+  it("defaults edge weight to 1", () => {
+    const g = createGraph({
+      numVertices: 2,
+      directed: true,
+      edges: [{ from: 0, to: 1 }],
+    });
+    expect(g.edges[0]!.weight).toBe(1);
+  });
+
+  it("preserves explicit weights", () => {
+    const g = createGraph({
+      numVertices: 2,
+      directed: true,
+      edges: [{ from: 0, to: 1, weight: 7 }],
+    });
+    expect(g.edges[0]!.weight).toBe(7);
+    expect(g.adjacency[0]![0]!.weight).toBe(7);
+  });
+
+  it("keeps the canonical edge list at one entry per undirected edge", () => {
+    const g = createGraph({
+      numVertices: 2,
+      directed: false,
+      edges: [{ from: 0, to: 1 }],
+    });
+    expect(g.edges.length).toBe(1);
+  });
+});
+
+describe("cloneGraph", () => {
+  it("produces a deep copy that is structurally equal", () => {
+    const g = sampleWeightedGraph();
+    const clone = cloneGraph(g);
+    expect(clone).toEqual(g);
+    expect(clone).not.toBe(g);
+    expect(clone.edges).not.toBe(g.edges);
+    expect(clone.adjacency).not.toBe(g.adjacency);
+  });
+});
+
+describe("sample graphs", () => {
+  it("sampleUndirectedGraph: 6 vertices, undirected, unit weights", () => {
+    const g = sampleUndirectedGraph();
+    expect(g.numVertices).toBe(6);
+    expect(g.directed).toBe(false);
+    expect(g.edges.every((e) => e.weight === 1)).toBe(true);
+  });
+
+  it("sampleWeightedGraph: 6 vertices, undirected, mixed weights", () => {
+    const g = sampleWeightedGraph();
+    expect(g.numVertices).toBe(6);
+    expect(g.directed).toBe(false);
+    expect(g.edges.some((e) => e.weight !== 1)).toBe(true);
+  });
+
+  it("sampleDAG: 6 vertices, directed", () => {
+    const g = sampleDAG();
+    expect(g.numVertices).toBe(6);
+    expect(g.directed).toBe(true);
+  });
+});
+
+describe("defaultGraphFor", () => {
+  it("maps each algorithm key to an appropriate graph", () => {
+    expect(defaultGraphFor("dfs").directed).toBe(false);
+    expect(defaultGraphFor("bfs").directed).toBe(false);
+    expect(defaultGraphFor("topologicalSort").directed).toBe(true);
+    expect(defaultGraphFor("dijkstra").edges.some((e) => e.weight !== 1)).toBe(
+      true
+    );
+  });
+});

--- a/__tests__/lib/algorithms/index.test.ts
+++ b/__tests__/lib/algorithms/index.test.ts
@@ -1,26 +1,69 @@
 import { describe, it, expect } from "vitest";
-import { getAlgorithmByName, isAlgorithmName } from "@/lib/algorithms";
+import {
+  getGraphAlgorithm,
+  getSearchAlgorithm,
+  getSortingAlgorithm,
+  isAlgorithmName,
+  isGraphAlgorithm,
+  isSearchAlgorithm,
+  isSortingAlgorithm,
+} from "@/lib/algorithms";
+import { sampleUndirectedGraph } from "@/lib/algorithms/graph/sampleGraphs";
 
-describe("getAlgorithmByName", () => {
-  it("returns the function for a known algorithm name", () => {
-    const fn = getAlgorithmByName("bubbleSort");
+describe("getSortingAlgorithm", () => {
+  it("returns the function for a known sorting algorithm", () => {
+    const fn = getSortingAlgorithm("bubbleSort");
     expect(fn).toBeTypeOf("function");
     const viz = fn!([3, 1, 2]);
     expect(viz.key).toBe("bubbleSort");
   });
 
-  it("returns null for an unknown name", () => {
-    expect(getAlgorithmByName("madeUpAlgorithm")).toBeNull();
+  it("returns null for non-sorting names", () => {
+    expect(getSortingAlgorithm("dfs")).toBeNull();
+    expect(getSortingAlgorithm("madeUp")).toBeNull();
   });
 });
 
-describe("isAlgorithmName", () => {
-  it("recognizes known algorithm names", () => {
-    expect(isAlgorithmName("dijkstra")).toBe(true);
-    expect(isAlgorithmName("topologicalSort")).toBe(true);
+describe("getSearchAlgorithm", () => {
+  it("returns the function for a known search algorithm", () => {
+    const fn = getSearchAlgorithm("linearSearch");
+    expect(fn).toBeTypeOf("function");
+    const viz = fn!([1, 2, 3], 2);
+    expect(viz.key).toBe("linearSearch");
   });
 
-  it("rejects unknown names", () => {
+  it("returns null for non-search names", () => {
+    expect(getSearchAlgorithm("bubbleSort")).toBeNull();
+  });
+});
+
+describe("getGraphAlgorithm", () => {
+  it("returns the function for a known graph algorithm", () => {
+    const fn = getGraphAlgorithm("dfs");
+    expect(fn).toBeTypeOf("function");
+    const viz = fn!(sampleUndirectedGraph(), 0);
+    expect(viz.key).toBe("dfs");
+  });
+
+  it("returns null for non-graph names", () => {
+    expect(getGraphAlgorithm("bubbleSort")).toBeNull();
+  });
+});
+
+describe("category guards", () => {
+  it("classify known algorithm keys correctly", () => {
+    expect(isSortingAlgorithm("bubbleSort")).toBe(true);
+    expect(isSortingAlgorithm("dfs")).toBe(false);
+    expect(isSearchAlgorithm("binarySearch")).toBe(true);
+    expect(isSearchAlgorithm("dfs")).toBe(false);
+    expect(isGraphAlgorithm("dijkstra")).toBe(true);
+    expect(isGraphAlgorithm("bubbleSort")).toBe(false);
+  });
+
+  it("isAlgorithmName accepts all categories and rejects unknown", () => {
+    expect(isAlgorithmName("dfs")).toBe(true);
+    expect(isAlgorithmName("bubbleSort")).toBe(true);
+    expect(isAlgorithmName("linearSearch")).toBe(true);
     expect(isAlgorithmName("nope")).toBe(false);
     expect(isAlgorithmName("")).toBe(false);
   });

--- a/app/graph/[algorithm]/page.tsx
+++ b/app/graph/[algorithm]/page.tsx
@@ -5,18 +5,21 @@ import { useParams } from "next/navigation";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
 import { useAlgorithm } from "@/context/AlgorithmContext";
-import { getAlgorithmByName } from "@/lib/algorithms";
+import { getGraphAlgorithm, isGraphAlgorithm } from "@/lib/algorithms";
+import { defaultGraphFor } from "@/lib/algorithms/graph/sampleGraphs";
 import { availableAlgorithms } from "@/lib/algorithms/metadata";
 
 function computeGraphViz(algorithmKey: string, target: number | undefined) {
-  let startVertex = 0;
-  if (target !== undefined && target >= 0 && target < 6) {
-    startVertex = target;
-  }
-  const algoFn = getAlgorithmByName(algorithmKey);
+  if (!isGraphAlgorithm(algorithmKey)) return { startVertex: 0, viz: null };
+  const graph = defaultGraphFor(algorithmKey);
+  const startVertex =
+    target !== undefined && target >= 0 && target < graph.numVertices
+      ? target
+      : 0;
+  const algoFn = getGraphAlgorithm(algorithmKey);
   if (!algoFn) return { startVertex, viz: null };
   try {
-    return { startVertex, viz: algoFn([], startVertex) };
+    return { startVertex, viz: algoFn(graph, startVertex) };
   } catch (error) {
     console.error("Error generating visualization:", error);
     return { startVertex, viz: null };

--- a/app/searching/[algorithm]/page.tsx
+++ b/app/searching/[algorithm]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, notFound } from "next/navigation";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
 import { useAlgorithm } from "@/context/AlgorithmContext";
-import { getAlgorithmByName } from "@/lib/algorithms";
+import { getSearchAlgorithm } from "@/lib/algorithms";
 import { getRandomValueFromArray } from "@/lib/utils";
 import { availableAlgorithms } from "@/lib/algorithms/metadata";
 
@@ -33,7 +33,7 @@ export default function SearchingAlgorithmPage() {
 
       // Generate visualization if not already generated OR if algorithm changed
       if (!state.visualizationData || algorithmKey !== state.algorithm) {
-        const algorithmFunction = getAlgorithmByName(algorithmKey);
+        const algorithmFunction = getSearchAlgorithm(algorithmKey);
         if (algorithmFunction) {
           try {
             const viz = algorithmFunction(data, target);

--- a/app/sorting/[algorithm]/page.tsx
+++ b/app/sorting/[algorithm]/page.tsx
@@ -5,7 +5,7 @@ import { useParams } from "next/navigation";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
 import { useAlgorithm } from "@/context/AlgorithmContext";
-import { getAlgorithmByName } from "@/lib/algorithms";
+import { getSortingAlgorithm } from "@/lib/algorithms";
 import { availableAlgorithms } from "@/lib/algorithms/metadata";
 
 export default function AlgorithmPage() {
@@ -22,7 +22,7 @@ export default function AlgorithmPage() {
 
       // Generate visualization if not already generated OR if algorithm changed
       if (!state.visualizationData || algorithmKey !== state.algorithm) {
-        const algorithmFunction = getAlgorithmByName(algorithmKey);
+        const algorithmFunction = getSortingAlgorithm(algorithmKey);
         if (algorithmFunction) {
           const viz = algorithmFunction(state.data);
           dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });

--- a/components/visualizer/AlgorithmVisualizer.tsx
+++ b/components/visualizer/AlgorithmVisualizer.tsx
@@ -8,65 +8,89 @@ import AlgorithmInfo from "./AlgorithmInfo";
 import AlgorithmPseudocode from "./AlgorithmPseudocode";
 import ColorLegend from "./ColorLegend";
 import { useAlgorithm } from "@/context/AlgorithmContext";
-import { getAlgorithmByName } from "@/lib/algorithms";
-import type { GraphStep, SearchStep, SortingStep } from "@/lib/types";
+import {
+  getGraphAlgorithm,
+  getSearchAlgorithm,
+  getSortingAlgorithm,
+  isGraphAlgorithm,
+} from "@/lib/algorithms";
+import { defaultGraphFor } from "@/lib/algorithms/graph/sampleGraphs";
+import type {
+  AlgorithmVisualization,
+  GraphStep,
+  SearchStep,
+  SortingStep,
+} from "@/lib/types";
+
+function regenerateGraph(algorithm: string): AlgorithmVisualization | null {
+  if (!isGraphAlgorithm(algorithm)) return null;
+  const graphFn = getGraphAlgorithm(algorithm);
+  if (!graphFn) return null;
+  try {
+    const graph = defaultGraphFor(algorithm);
+    const startVertex = Math.floor(Math.random() * graph.numVertices);
+    return graphFn(graph, startVertex);
+  } catch (error) {
+    console.error("Error generating graph visualization:", error);
+    return null;
+  }
+}
+
+function regenerateSearch(
+  algorithm: string,
+  data: number[],
+  target: number
+): AlgorithmVisualization | null {
+  const fn = getSearchAlgorithm(algorithm);
+  if (!fn) return null;
+  try {
+    const newData =
+      algorithm === "binarySearch" ? [...data].sort((a, b) => a - b) : data;
+    return fn(newData, target);
+  } catch (error) {
+    console.error("Error generating visualization:", error);
+    return null;
+  }
+}
+
+function regenerateSort(
+  algorithm: string,
+  data: number[]
+): AlgorithmVisualization | null {
+  const fn = getSortingAlgorithm(algorithm);
+  if (!fn) return null;
+  try {
+    return fn(data);
+  } catch (error) {
+    console.error("Error generating visualization:", error);
+    return null;
+  }
+}
 
 export default function AlgorithmVisualizer() {
   const { state, dispatch } = useAlgorithm();
   const { currentStep, algorithm, data, visualizationData, target } = state;
+  const category = visualizationData?.category ?? "";
 
-  // Function to generate new data based on algorithm type
   const handleGenerateNewData = () => {
-    // For graph algorithms, we just need to regenerate with a new starting vertex
     if (category === "graph") {
-      const algorithmFunction = getAlgorithmByName(algorithm);
-      if (algorithmFunction) {
-        try {
-          // Generate a random starting vertex between 0-5
-          const startVertex = Math.floor(Math.random() * 6);
-          const viz = algorithmFunction([], startVertex);
-          dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
-        } catch (error) {
-          console.error("Error generating graph visualization:", error);
-        }
-      }
+      const viz = regenerateGraph(algorithm);
+      if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
       return;
     }
 
-    // For array-based algorithms, generate a new random array
     dispatch({
       type: "GENERATE_RANDOM_DATA",
       payload: { min: 5, max: 95, length: 15 },
     });
 
-    // Regenerate visualization with the new data
-    const algorithmFunction = getAlgorithmByName(algorithm);
-    if (algorithmFunction) {
-      try {
-        let viz;
-
-        if (algorithm === "binarySearch") {
-          // For binary search - ensure sorted array and target exists
-          const newData = [...state.data].sort((a, b) => a - b);
-          viz = algorithmFunction(newData, target);
-        } else {
-          // For other algorithms like sorting
-          viz = algorithmFunction(state.data, target);
-        }
-
-        dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
-      } catch (error) {
-        console.error("Error generating visualization:", error);
-      }
-    }
+    const viz =
+      category === "searching"
+        ? regenerateSearch(algorithm, state.data, target ?? 0)
+        : regenerateSort(algorithm, state.data);
+    if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
   };
 
-  // Check the algorithm category
-  const getAlgorithmCategory = () => {
-    return visualizationData?.category || "";
-  };
-
-  // Find the maximum value in the array for scaling
   const maxValue = data.length > 0 ? Math.max(...data) : 100;
 
   if (!visualizationData) {
@@ -79,8 +103,6 @@ export default function AlgorithmVisualizer() {
       </div>
     );
   }
-
-  const category = getAlgorithmCategory();
 
   return (
     <div className="space-y-8">

--- a/components/visualizer/GraphVisualization.tsx
+++ b/components/visualizer/GraphVisualization.tsx
@@ -1,6 +1,10 @@
-import type { GraphStep } from "@/lib/types";
+import type { Edge, GraphStep } from "@/lib/types";
 import { useState, useEffect } from "react";
 import type { ReactNode } from "react";
+
+const VERTEX_RADIUS = 20;
+const EDGE_COLOR = "#CBD5E1";
+const PATH_EDGE_COLOR = "#F87171";
 
 function getStatusMessage(
   current: number,
@@ -12,8 +16,113 @@ function getStatusMessage(
   if (stack.length > 0)
     return <p>Starting exploration from vertex {stack[0] ?? 0}.</p>;
   if (path.length > 0)
-    return <p>DFS traversal complete. Path: {path.join(" → ")}</p>;
-  return <p>DFS traversal will start from a selected vertex.</p>;
+    return <p>Traversal complete. Path: {path.join(" → ")}</p>;
+  return <p>Traversal will start from a selected vertex.</p>;
+}
+
+function getMarkerEnd(
+  showArrows: boolean,
+  onPath: boolean
+): string | undefined {
+  if (!showArrows) return undefined;
+  return onPath ? "url(#arrowhead-path)" : "url(#arrowhead)";
+}
+
+function ArrowDefs() {
+  return (
+    <defs>
+      <marker
+        id="arrowhead"
+        viewBox="0 0 10 10"
+        refX="10"
+        refY="5"
+        markerWidth="6"
+        markerHeight="6"
+        orient="auto-start-reverse"
+      >
+        <path d="M 0 0 L 10 5 L 0 10 z" fill={EDGE_COLOR} />
+      </marker>
+      <marker
+        id="arrowhead-path"
+        viewBox="0 0 10 10"
+        refX="10"
+        refY="5"
+        markerWidth="6"
+        markerHeight="6"
+        orient="auto-start-reverse"
+      >
+        <path d="M 0 0 L 10 5 L 0 10 z" fill={PATH_EDGE_COLOR} />
+      </marker>
+    </defs>
+  );
+}
+
+interface EdgeShapeProps {
+  edge: Edge;
+  from: { x: number; y: number };
+  to: { x: number; y: number };
+  onPath: boolean;
+  showArrows: boolean;
+  showWeights: boolean;
+}
+
+function EdgeShape({
+  edge,
+  from,
+  to,
+  onPath,
+  showArrows,
+  showWeights,
+}: EdgeShapeProps) {
+  const stroke = onPath ? PATH_EDGE_COLOR : EDGE_COLOR;
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+  const ux = dx / dist;
+  const uy = dy / dist;
+  const x2 = to.x - ux * VERTEX_RADIUS;
+  const y2 = to.y - uy * VERTEX_RADIUS;
+  const x1 = showArrows ? from.x + ux * VERTEX_RADIUS : from.x;
+  const y1 = showArrows ? from.y + uy * VERTEX_RADIUS : from.y;
+  const midX = (from.x + to.x) / 2;
+  const midY = (from.y + to.y) / 2;
+
+  return (
+    <g>
+      <line
+        x1={x1}
+        y1={y1}
+        x2={x2}
+        y2={y2}
+        stroke={stroke}
+        strokeWidth={2}
+        markerEnd={getMarkerEnd(showArrows, onPath)}
+      />
+      {showWeights && (
+        <g>
+          <rect
+            x={midX - 10}
+            y={midY - 9}
+            width={20}
+            height={16}
+            rx={3}
+            fill="white"
+            opacity={0.9}
+          />
+          <text
+            x={midX}
+            y={midY + 3}
+            textAnchor="middle"
+            fontSize={11}
+            fill="#374151"
+            fontWeight={600}
+          >
+            {edge.weight}
+          </text>
+        </g>
+      )}
+    </g>
+  );
 }
 
 interface GraphVisualizationProps {
@@ -21,10 +130,9 @@ interface GraphVisualizationProps {
 }
 
 export default function GraphVisualization({ step }: GraphVisualizationProps) {
-  const { adjacencyList, current, visited, stack, path } = step;
+  const { graph, current, visited, stack, path } = step;
   const [graphSize, setGraphSize] = useState({ width: 0, height: 0 });
 
-  // Calculate layout dimensions based on window size
   useEffect(() => {
     const updateSize = () => {
       const width = Math.min(600, window.innerWidth - 40);
@@ -37,48 +145,41 @@ export default function GraphVisualization({ step }: GraphVisualizationProps) {
     return () => window.removeEventListener("resize", updateSize);
   }, []);
 
-  // Check if adjacencyList is valid
-  if (
-    !adjacencyList ||
-    !Array.isArray(adjacencyList) ||
-    adjacencyList.length === 0
-  ) {
+  if (!graph || graph.numVertices === 0) {
     return (
       <div className="flex items-center justify-center bg-white p-6 text-red-500">
-        Invalid graph data. Please check the adjacency list.
+        Invalid graph data.
       </div>
     );
   }
 
-  // Calculate coordinates for each vertex in a circular layout
-  const vertexPositions = adjacencyList.map((_, index) => {
-    const angle = (2 * Math.PI * index) / adjacencyList.length;
-    const radius = Math.min(graphSize.width, graphSize.height) * 0.35;
-    return {
-      x: graphSize.width / 2 + radius * Math.cos(angle),
-      y: graphSize.height / 2 + radius * Math.sin(angle),
-    };
-  });
+  const vertexPositions = Array.from(
+    { length: graph.numVertices },
+    (_, index) => {
+      const angle = (2 * Math.PI * index) / graph.numVertices;
+      const radius = Math.min(graphSize.width, graphSize.height) * 0.35;
+      return {
+        x: graphSize.width / 2 + radius * Math.cos(angle),
+        y: graphSize.height / 2 + radius * Math.sin(angle),
+      };
+    }
+  );
 
-  // Function to determine vertex color based on its state
   const getVertexColor = (index: number) => {
-    if (index === current) return "#FCD34D"; // yellow-300
-    if (visited.includes(index)) return "#6EE7B7"; // green-300
-    return "#93C5FD"; // blue-300
+    if (index === current) return "#FCD34D";
+    if (visited.includes(index)) return "#6EE7B7";
+    return "#93C5FD";
   };
 
-  // Function to determine edge color based on whether it's in the path
-  const getEdgeColor = (source: number, target: number) => {
-    // Check if this edge is part of the current path
-    const sourceInPath = path.includes(source);
-    const targetInPath = path.includes(target);
-    const adjacentInPath =
-      sourceInPath &&
-      targetInPath &&
-      Math.abs(path.indexOf(source) - path.indexOf(target)) === 1;
-
-    return adjacentInPath ? "#F87171" : "#CBD5E1"; // red-400 : gray-300
+  const isEdgeOnPath = (from: number, to: number) => {
+    const fromIdx = path.indexOf(from);
+    const toIdx = path.indexOf(to);
+    if (fromIdx === -1 || toIdx === -1) return false;
+    return Math.abs(fromIdx - toIdx) === 1;
   };
+
+  const showWeights = graph.edges.some((e) => e.weight !== 1);
+  const showArrows = graph.directed;
 
   return (
     <div className="flex w-full flex-col items-center bg-white p-6">
@@ -95,38 +196,31 @@ export default function GraphVisualization({ step }: GraphVisualizationProps) {
         className="relative rounded-lg border bg-gray-50"
         style={{ width: graphSize.width, height: graphSize.height }}
       >
-        {/* Draw edges */}
         <svg width={graphSize.width} height={graphSize.height}>
-          {adjacencyList.map((neighbors, vertex) =>
-            neighbors.map(
-              (neighbor) =>
-                // Only draw each edge once
-                vertex < neighbor && (
-                  <line
-                    key={`${vertex}-${neighbor}`}
-                    x1={vertexPositions[vertex]!.x}
-                    y1={vertexPositions[vertex]!.y}
-                    x2={vertexPositions[neighbor]!.x}
-                    y2={vertexPositions[neighbor]!.y}
-                    stroke={getEdgeColor(vertex, neighbor)}
-                    strokeWidth={2}
-                  />
-                )
-            )
-          )}
+          <ArrowDefs />
+          {graph.edges.map((edge, i) => (
+            <EdgeShape
+              key={i}
+              edge={edge}
+              from={vertexPositions[edge.from]!}
+              to={vertexPositions[edge.to]!}
+              onPath={isEdgeOnPath(edge.from, edge.to)}
+              showArrows={showArrows}
+              showWeights={showWeights}
+            />
+          ))}
         </svg>
 
-        {/* Draw vertices */}
         {vertexPositions.map((pos, index) => (
           <div
             key={index}
             className="absolute flex items-center justify-center rounded-full font-bold text-white transition-all duration-300"
             style={{
-              width: 40,
-              height: 40,
+              width: VERTEX_RADIUS * 2,
+              height: VERTEX_RADIUS * 2,
               backgroundColor: getVertexColor(index),
-              left: pos.x - 20,
-              top: pos.y - 20,
+              left: pos.x - VERTEX_RADIUS,
+              top: pos.y - VERTEX_RADIUS,
               border: index === current ? "3px solid #EF4444" : "none",
             }}
           >

--- a/components/visualizer/SearchVisualization.tsx
+++ b/components/visualizer/SearchVisualization.tsx
@@ -1,6 +1,6 @@
 import type { SearchStep } from "@/lib/types";
 import { useAlgorithm } from "@/context/AlgorithmContext";
-import { getAlgorithmByName } from "@/lib/algorithms";
+import { getSearchAlgorithm } from "@/lib/algorithms";
 import { useState, useEffect } from "react";
 
 interface SearchVisualizationProps {
@@ -36,7 +36,7 @@ export default function SearchVisualization({
     dispatch({ type: "SET_TARGET", payload: newTarget });
 
     // Regenerate visualization with the new target
-    const algorithmFunction = getAlgorithmByName(state.algorithm);
+    const algorithmFunction = getSearchAlgorithm(state.algorithm);
     if (algorithmFunction) {
       try {
         const viz = algorithmFunction(state.data, newTarget);

--- a/lib/algorithms/graph/bfs.ts
+++ b/lib/algorithms/graph/bfs.ts
@@ -1,92 +1,58 @@
-import type { AlgorithmVisualization, GraphStep } from "../../types";
+import type { AlgorithmVisualization, Graph, GraphStep } from "../../types";
+import { cloneGraph } from "./sampleGraphs";
 import { createVisualization } from "../utils";
 
 export function bfs(
-  array: number[],
-  target: number = 0
+  graph: Graph,
+  startVertex: number = 0
 ): AlgorithmVisualization {
-  // Ignore the input array and use a predefined adjacency list for graph visualization
-  // The target parameter will be used as the starting vertex, but ensure it's valid
-  // Create a sample graph as an adjacency list first
-  const adjacencyList: number[][] = [
-    [1, 2], // Vertex 0 connected to 1, 2
-    [0, 3, 4], // Vertex 1 connected to 0, 3, 4
-    [0, 5], // Vertex 2 connected to 0, 5
-    [1], // Vertex 3 connected to 1
-    [1, 5], // Vertex 4 connected to 1, 5
-    [2, 4], // Vertex 5 connected to 2, 4
-  ];
-
-  // Ensure startVertex is valid (0 to 5)
-  const startVertex = target >= 0 && target < adjacencyList.length ? target : 0;
+  const start =
+    startVertex >= 0 && startVertex < graph.numVertices ? startVertex : 0;
 
   const steps: GraphStep[] = [];
   const visited: number[] = [];
-  const queue: number[] = [startVertex];
+  const queue: number[] = [start];
   const path: number[] = [];
 
-  // Initial state
-  steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]), // Deep copy
-    current: -1,
+  const snapshot = (current: number): GraphStep => ({
+    graph: cloneGraph(graph),
+    current,
     visited: [...visited],
-    stack: [...queue], // Using stack field to represent queue in visualization
+    stack: [...queue],
     path: [...path],
   });
 
-  // Mark the start vertex as visited before starting the main loop
-  visited.push(startVertex);
+  steps.push(snapshot(-1));
+
+  visited.push(start);
 
   while (queue.length > 0) {
-    // Get the next vertex from the queue
     const current = queue.shift()!;
-
-    // Add current to path
     path.push(current);
 
-    // Add step for current vertex visit
-    steps.push({
-      adjacencyList: adjacencyList.map((row) => [...row]),
-      current,
-      visited: [...visited],
-      stack: [...queue], // Using stack field to represent queue in visualization
-      path: [...path],
-    });
+    steps.push(snapshot(current));
 
-    // Get all adjacent vertices
-    const neighbors = [...adjacencyList[current]!];
-
-    // For each unvisited neighbor
-    for (const neighbor of neighbors) {
+    for (const edge of graph.adjacency[current]!) {
+      const neighbor = edge.to;
       if (!visited.includes(neighbor)) {
-        // Mark as visited and add to queue
         visited.push(neighbor);
         queue.push(neighbor);
-
-        // Add step showing queue update
-        steps.push({
-          adjacencyList: adjacencyList.map((row) => [...row]),
-          current,
-          visited: [...visited],
-          stack: [...queue], // Using stack field to represent queue in visualization
-          path: [...path],
-        });
+        steps.push(snapshot(current));
       }
     }
   }
 
-  // Final state
   steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]),
+    graph: cloneGraph(graph),
     current: -1,
     visited: [...visited],
-    stack: [], // Queue is empty now
+    stack: [],
     path: [...path],
   });
 
   return createVisualization("bfs", steps, {
-    timeComplexity: "O(V + E)", // Vertices + Edges
-    spaceComplexity: "O(V)", // Vertices for queue and visited set
+    timeComplexity: "O(V + E)",
+    spaceComplexity: "O(V)",
     reference: "https://en.wikipedia.org/wiki/Breadth-first_search",
     pseudoCode: [
       "procedure BFS(G, start_v)",

--- a/lib/algorithms/graph/dfs.ts
+++ b/lib/algorithms/graph/dfs.ts
@@ -1,89 +1,54 @@
-import type { AlgorithmVisualization, GraphStep } from "../../types";
+import type { AlgorithmVisualization, Graph, GraphStep } from "../../types";
+import { cloneGraph } from "./sampleGraphs";
 import { createVisualization } from "../utils";
 
 export function dfs(
-  array: number[],
-  target: number = 0
+  graph: Graph,
+  startVertex: number = 0
 ): AlgorithmVisualization {
-  // Ignore the input array and use a predefined adjacency list for graph visualization
-  // The target parameter will be used as the starting vertex, but ensure it's valid
-  // Create a sample graph as an adjacency list first
-  const adjacencyList: number[][] = [
-    [1, 2], // Vertex 0 connected to 1, 2
-    [0, 3, 4], // Vertex 1 connected to 0, 3, 4
-    [0, 5], // Vertex 2 connected to 0, 5
-    [1], // Vertex 3 connected to 1
-    [1, 5], // Vertex 4 connected to 1, 5
-    [2, 4], // Vertex 5 connected to 2, 4
-  ];
-
-  // Ensure startVertex is valid (0 to 5)
-  const startVertex = target >= 0 && target < adjacencyList.length ? target : 0;
-
-  // We've already defined the adjacencyList above
+  const start =
+    startVertex >= 0 && startVertex < graph.numVertices ? startVertex : 0;
 
   const steps: GraphStep[] = [];
   const visited: number[] = [];
-  const stack: number[] = [startVertex];
+  const stack: number[] = [start];
   const path: number[] = [];
 
-  // Initial state
-  steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]), // Deep copy
-    current: -1,
+  const snapshot = (current: number): GraphStep => ({
+    graph: cloneGraph(graph),
+    current,
     visited: [...visited],
     stack: [...stack],
     path: [...path],
   });
 
+  steps.push(snapshot(-1));
+
   while (stack.length > 0) {
-    // Get the next vertex from the stack
     const current = stack.pop()!;
 
-    // Skip if already visited
     if (visited.includes(current)) continue;
+    if (current < 0 || current >= graph.numVertices) continue;
 
-    // Make sure current vertex is valid
-    if (current < 0 || current >= adjacencyList.length) continue;
-
-    // Mark as visited
     visited.push(current);
     path.push(current);
 
-    // Add step for current vertex visit
-    steps.push({
-      adjacencyList: adjacencyList.map((row) => [...row]),
-      current,
-      visited: [...visited],
-      stack: [...stack],
-      path: [...path],
-    });
+    steps.push(snapshot(current));
 
-    // Get all adjacent vertices in reverse order (so they come off the stack in correct order)
-    // Ensure the current index is valid in the adjacency list
-    const neighbors = [...adjacencyList[current]!].reverse();
+    const neighbors = [...graph.adjacency[current]!]
+      .map((edge) => edge.to)
+      .reverse();
 
-    // For each neighbor
     for (const neighbor of neighbors) {
-      // If not visited, add to stack
       if (!visited.includes(neighbor)) {
         stack.push(neighbor);
-
-        // Add step showing stack update
-        steps.push({
-          adjacencyList: adjacencyList.map((row) => [...row]),
-          current,
-          visited: [...visited],
-          stack: [...stack],
-          path: [...path],
-        });
+        steps.push(snapshot(current));
       }
     }
   }
 
-  // Final state
   steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]),
+    graph: cloneGraph(graph),
     current: -1,
     visited: [...visited],
     stack: [],
@@ -91,8 +56,8 @@ export function dfs(
   });
 
   return createVisualization("dfs", steps, {
-    timeComplexity: "O(V + E)", // Vertices + Edges
-    spaceComplexity: "O(V)", // Vertices for stack and visited set
+    timeComplexity: "O(V + E)",
+    spaceComplexity: "O(V)",
     reference: "https://en.wikipedia.org/wiki/Depth-first_search",
     pseudoCode: [
       "procedure DFS(G, start_v)",

--- a/lib/algorithms/graph/dijkstra.ts
+++ b/lib/algorithms/graph/dijkstra.ts
@@ -1,4 +1,5 @@
-import type { AlgorithmVisualization, GraphStep } from "../../types";
+import type { AlgorithmVisualization, Graph, GraphStep } from "../../types";
+import { cloneGraph } from "./sampleGraphs";
 import { createVisualization } from "../utils";
 
 interface DijkstraState {
@@ -7,7 +8,17 @@ interface DijkstraState {
   path: number[];
   queue: number[];
   steps: GraphStep[];
-  adjacencyList: number[][];
+  graph: Graph;
+}
+
+function snapshot(state: DijkstraState, current: number): GraphStep {
+  return {
+    graph: cloneGraph(state.graph),
+    current,
+    visited: [...state.visited],
+    stack: [...state.queue],
+    path: [...state.path],
+  };
 }
 
 function findMinVertex(dist: number[], visited: number[], V: number): number {
@@ -22,40 +33,22 @@ function findMinVertex(dist: number[], visited: number[], V: number): number {
   return minIndex;
 }
 
-function relaxEdgesFrom(
-  graph: number[][],
-  minIndex: number,
-  state: DijkstraState
-): void {
-  const V = graph.length;
-  const graphRow = graph[minIndex]!;
+function relaxEdgesFrom(state: DijkstraState, minIndex: number): void {
   const distMin = state.dist[minIndex]!;
-
-  for (let v = 0; v < V; v++) {
-    const edgeWeight = graphRow[v]!;
+  for (const edge of state.graph.adjacency[minIndex]!) {
+    const v = edge.to;
+    if (state.visited.includes(v)) continue;
     const distV = state.dist[v]!;
-    if (
-      !state.visited.includes(v) &&
-      edgeWeight !== 0 &&
-      edgeWeight !== Infinity &&
-      distMin !== Infinity &&
-      distMin + edgeWeight < distV
-    ) {
-      state.dist[v] = distMin + edgeWeight;
+    if (distMin !== Infinity && distMin + edge.weight < distV) {
+      state.dist[v] = distMin + edge.weight;
       if (!state.queue.includes(v)) state.queue.push(v);
-      state.steps.push({
-        adjacencyList: state.adjacencyList.map((row) => [...row]),
-        current: minIndex,
-        visited: [...state.visited],
-        stack: [...state.queue],
-        path: [...state.path],
-      });
+      state.steps.push(snapshot(state, minIndex));
     }
   }
 }
 
-function runDijkstra(graph: number[][], state: DijkstraState): void {
-  const V = graph.length;
+function runDijkstra(state: DijkstraState): void {
+  const V = state.graph.numVertices;
   for (let count = 0; count < V; count++) {
     const minIndex = findMinVertex(state.dist, state.visited, V);
     if (minIndex === -1) break;
@@ -63,15 +56,9 @@ function runDijkstra(graph: number[][], state: DijkstraState): void {
     state.visited.push(minIndex);
     state.path.push(minIndex);
 
-    state.steps.push({
-      adjacencyList: state.adjacencyList.map((row) => [...row]),
-      current: minIndex,
-      visited: [...state.visited],
-      stack: [...state.queue],
-      path: [...state.path],
-    });
+    state.steps.push(snapshot(state, minIndex));
 
-    relaxEdgesFrom(graph, minIndex, state);
+    relaxEdgesFrom(state, minIndex);
 
     const currentIndex = state.queue.indexOf(minIndex);
     if (currentIndex !== -1) state.queue.splice(currentIndex, 1);
@@ -79,27 +66,11 @@ function runDijkstra(graph: number[][], state: DijkstraState): void {
 }
 
 export function dijkstra(
-  array: number[],
+  graph: Graph,
   source: number = 0
 ): AlgorithmVisualization {
-  const graph: number[][] = [
-    [0, 4, 2, Infinity, Infinity, Infinity],
-    [4, 0, 1, 5, 2, Infinity],
-    [2, 1, 0, Infinity, 3, 6],
-    [Infinity, 5, Infinity, 0, 2, Infinity],
-    [Infinity, 2, 3, 2, 0, 1],
-    [Infinity, Infinity, 6, Infinity, 1, 0],
-  ];
-
-  const startVertex = source >= 0 && source < graph.length ? source : 0;
-  const V = graph.length;
-
-  const adjacencyList: number[][] = graph.map((row) =>
-    row.reduce((neighbors, weight, j) => {
-      if (weight !== Infinity && weight !== 0) neighbors.push(j);
-      return neighbors;
-    }, [] as number[])
-  );
+  const startVertex = source >= 0 && source < graph.numVertices ? source : 0;
+  const V = graph.numVertices;
 
   const dist: number[] = Array(V).fill(Infinity);
   dist[startVertex] = 0;
@@ -110,21 +81,21 @@ export function dijkstra(
     path: [],
     queue: [startVertex],
     steps: [],
-    adjacencyList,
+    graph,
   };
 
   state.steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]),
+    graph: cloneGraph(graph),
     current: -1,
     visited: [],
     stack: [startVertex],
     path: [],
   });
 
-  runDijkstra(graph, state);
+  runDijkstra(state);
 
   state.steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]),
+    graph: cloneGraph(graph),
     current: -1,
     visited: [...state.visited],
     stack: [],

--- a/lib/algorithms/graph/sampleGraphs.ts
+++ b/lib/algorithms/graph/sampleGraphs.ts
@@ -1,0 +1,101 @@
+import type { Edge, Graph } from "../../types";
+
+export function createGraph(params: {
+  numVertices: number;
+  edges: Array<{ from: number; to: number; weight?: number }>;
+  directed: boolean;
+}): Graph {
+  const { numVertices, directed } = params;
+  const edges: Edge[] = params.edges.map((e) => ({
+    from: e.from,
+    to: e.to,
+    weight: e.weight ?? 1,
+  }));
+  const adjacency: Edge[][] = Array.from({ length: numVertices }, () => []);
+  for (const edge of edges) {
+    adjacency[edge.from]!.push(edge);
+    if (!directed) {
+      adjacency[edge.to]!.push({
+        from: edge.to,
+        to: edge.from,
+        weight: edge.weight,
+      });
+    }
+  }
+  return { numVertices, edges, adjacency, directed };
+}
+
+export function cloneGraph(graph: Graph): Graph {
+  return createGraph({
+    numVertices: graph.numVertices,
+    edges: graph.edges.map((e) => ({
+      from: e.from,
+      to: e.to,
+      weight: e.weight,
+    })),
+    directed: graph.directed,
+  });
+}
+
+export function sampleUndirectedGraph(): Graph {
+  return createGraph({
+    numVertices: 6,
+    directed: false,
+    edges: [
+      { from: 0, to: 1 },
+      { from: 0, to: 2 },
+      { from: 1, to: 3 },
+      { from: 1, to: 4 },
+      { from: 2, to: 5 },
+      { from: 4, to: 5 },
+    ],
+  });
+}
+
+export function sampleWeightedGraph(): Graph {
+  return createGraph({
+    numVertices: 6,
+    directed: false,
+    edges: [
+      { from: 0, to: 1, weight: 4 },
+      { from: 0, to: 2, weight: 2 },
+      { from: 1, to: 2, weight: 1 },
+      { from: 1, to: 3, weight: 5 },
+      { from: 1, to: 4, weight: 2 },
+      { from: 2, to: 4, weight: 3 },
+      { from: 2, to: 5, weight: 6 },
+      { from: 3, to: 4, weight: 2 },
+      { from: 4, to: 5, weight: 1 },
+    ],
+  });
+}
+
+export function sampleDAG(): Graph {
+  return createGraph({
+    numVertices: 6,
+    directed: true,
+    edges: [
+      { from: 0, to: 1 },
+      { from: 0, to: 2 },
+      { from: 1, to: 3 },
+      { from: 2, to: 3 },
+      { from: 2, to: 4 },
+      { from: 3, to: 5 },
+      { from: 4, to: 5 },
+    ],
+  });
+}
+
+export type GraphAlgorithmKey = "dfs" | "bfs" | "dijkstra" | "topologicalSort";
+
+export function defaultGraphFor(key: GraphAlgorithmKey): Graph {
+  switch (key) {
+    case "dijkstra":
+      return sampleWeightedGraph();
+    case "topologicalSort":
+      return sampleDAG();
+    case "dfs":
+    case "bfs":
+      return sampleUndirectedGraph();
+  }
+}

--- a/lib/algorithms/graph/topologicalSort.ts
+++ b/lib/algorithms/graph/topologicalSort.ts
@@ -1,8 +1,9 @@
-import type { AlgorithmVisualization, GraphStep } from "../../types";
+import type { AlgorithmVisualization, Graph, GraphStep } from "../../types";
+import { cloneGraph } from "./sampleGraphs";
 import { createVisualization } from "../utils";
 
 interface TopoSortState {
-  adjacencyList: number[][];
+  graph: Graph;
   steps: GraphStep[];
   visited: number[];
   stack: number[];
@@ -10,19 +11,24 @@ interface TopoSortState {
   tempVisited: number[];
 }
 
+function snapshot(state: TopoSortState, current: number): GraphStep {
+  return {
+    graph: cloneGraph(state.graph),
+    current,
+    visited: [...state.visited],
+    stack: [...state.stack],
+    path: [...state.path],
+  };
+}
+
 function dfsVisit(vertex: number, state: TopoSortState): void {
   state.tempVisited.push(vertex);
   state.path.push(vertex);
 
-  state.steps.push({
-    adjacencyList: state.adjacencyList.map((row) => [...row]),
-    current: vertex,
-    visited: [...state.visited],
-    stack: [...state.stack],
-    path: [...state.path],
-  });
+  state.steps.push(snapshot(state, vertex));
 
-  for (const neighbor of state.adjacencyList[vertex]!) {
+  for (const edge of state.graph.adjacency[vertex]!) {
+    const neighbor = edge.to;
     if (state.visited.includes(neighbor)) continue;
     if (state.tempVisited.includes(neighbor)) continue;
     dfsVisit(neighbor, state);
@@ -34,24 +40,16 @@ function dfsVisit(vertex: number, state: TopoSortState): void {
   state.visited.push(vertex);
   state.stack.unshift(vertex);
 
-  state.steps.push({
-    adjacencyList: state.adjacencyList.map((row) => [...row]),
-    current: vertex,
-    visited: [...state.visited],
-    stack: [...state.stack],
-    path: [...state.path],
-  });
+  state.steps.push(snapshot(state, vertex));
 }
 
 export function topologicalSort(
-  array: number[],
+  graph: Graph,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _target: number = 0
+  _startVertex: number = 0
 ): AlgorithmVisualization {
-  const adjacencyList: number[][] = [[1, 2], [3], [3, 4], [5], [5], []];
-
   const state: TopoSortState = {
-    adjacencyList,
+    graph,
     steps: [],
     visited: [],
     stack: [],
@@ -60,21 +58,21 @@ export function topologicalSort(
   };
 
   state.steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]),
+    graph: cloneGraph(graph),
     current: -1,
     visited: [],
     stack: [],
     path: [],
   });
 
-  for (let i = 0; i < adjacencyList.length; i++) {
+  for (let i = 0; i < graph.numVertices; i++) {
     if (!state.visited.includes(i) && !state.tempVisited.includes(i)) {
       dfsVisit(i, state);
     }
   }
 
   state.steps.push({
-    adjacencyList: adjacencyList.map((row) => [...row]),
+    graph: cloneGraph(graph),
     current: -1,
     visited: [...state.visited],
     stack: [...state.stack],

--- a/lib/algorithms/index.ts
+++ b/lib/algorithms/index.ts
@@ -1,4 +1,4 @@
-import type { AlgorithmVisualization } from "../types";
+import type { AlgorithmVisualization, Graph } from "../types";
 import { bubbleSort } from "./sorting/bubbleSort";
 import { selectionSort } from "./sorting/selectionSort";
 import { insertionSort } from "./sorting/insertionSort";
@@ -12,34 +12,75 @@ import { bfs } from "./graph/bfs";
 import { dijkstra } from "./graph/dijkstra";
 import { topologicalSort } from "./graph/topologicalSort";
 
-export type AlgorithmFn = (
+export type SortingFn = (array: number[]) => AlgorithmVisualization;
+export type SearchFn = (
   array: number[],
-  targetOrStart?: number
+  target: number
+) => AlgorithmVisualization;
+export type GraphFn = (
+  graph: Graph,
+  startVertex?: number
 ) => AlgorithmVisualization;
 
-const algorithms = {
+const sortingAlgorithms = {
   bubbleSort,
   selectionSort,
   insertionSort,
   mergeSort,
   quickSort,
   heapSort,
+} as const satisfies Record<string, SortingFn>;
+
+const searchAlgorithms = {
   linearSearch,
   binarySearch,
+} as const satisfies Record<string, SearchFn>;
+
+const graphAlgorithms = {
   dfs,
   bfs,
   dijkstra,
   topologicalSort,
-} as const satisfies Record<string, AlgorithmFn>;
+} as const satisfies Record<string, GraphFn>;
 
-export type AlgorithmName = keyof typeof algorithms;
+export type SortingAlgorithmName = keyof typeof sortingAlgorithms;
+export type SearchAlgorithmName = keyof typeof searchAlgorithms;
+export type GraphAlgorithmName = keyof typeof graphAlgorithms;
+export type AlgorithmName =
+  | SortingAlgorithmName
+  | SearchAlgorithmName
+  | GraphAlgorithmName;
 
-export function isAlgorithmName(name: string): name is AlgorithmName {
-  return name in algorithms;
+export function isSortingAlgorithm(name: string): name is SortingAlgorithmName {
+  return name in sortingAlgorithms;
 }
 
-export function getAlgorithmByName(name: string): AlgorithmFn | null {
-  return isAlgorithmName(name) ? algorithms[name] : null;
+export function isSearchAlgorithm(name: string): name is SearchAlgorithmName {
+  return name in searchAlgorithms;
+}
+
+export function isGraphAlgorithm(name: string): name is GraphAlgorithmName {
+  return name in graphAlgorithms;
+}
+
+export function isAlgorithmName(name: string): name is AlgorithmName {
+  return (
+    isSortingAlgorithm(name) ||
+    isSearchAlgorithm(name) ||
+    isGraphAlgorithm(name)
+  );
+}
+
+export function getSortingAlgorithm(name: string): SortingFn | null {
+  return isSortingAlgorithm(name) ? sortingAlgorithms[name] : null;
+}
+
+export function getSearchAlgorithm(name: string): SearchFn | null {
+  return isSearchAlgorithm(name) ? searchAlgorithms[name] : null;
+}
+
+export function getGraphAlgorithm(name: string): GraphFn | null {
+  return isGraphAlgorithm(name) ? graphAlgorithms[name] : null;
 }
 
 export {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -13,12 +13,25 @@ export interface SearchStep {
   visited: number[]; // Indices already visited
 }
 
+export interface Edge {
+  from: number;
+  to: number;
+  weight: number;
+}
+
+export interface Graph {
+  numVertices: number;
+  edges: Edge[];
+  adjacency: Edge[][];
+  directed: boolean;
+}
+
 export interface GraphStep {
-  adjacencyList: number[][]; // Adjacency list representation
-  current: number; // Current vertex index
-  visited: number[]; // Visited vertices
-  stack: number[]; // Stack for DFS traversal
-  path: number[]; // Path taken so far
+  graph: Graph;
+  current: number;
+  visited: number[];
+  stack: number[];
+  path: number[];
 }
 
 export interface AlgorithmVisualization {


### PR DESCRIPTION
## Summary
- Introduces a real `Graph` type (`Edge[]` canonical list + derived adjacency, `directed` flag) and embeds it in `GraphStep`. The four graph algorithms (DFS/BFS/Dijkstra/topological sort) now take `(graph: Graph, startVertex?)` instead of ignoring the input array and using hardcoded data.
- Extracts the per-algorithm hardcoded graphs into `lib/algorithms/graph/sampleGraphs.ts` (`createGraph` builder, `sampleUndirectedGraph` / `sampleWeightedGraph` / `sampleDAG`, `defaultGraphFor` lookup).
- Splits the algorithm registry into category-typed lookups (`getSortingAlgorithm` / `getSearchAlgorithm` / `getGraphAlgorithm`) so the `GraphFn` signature is no longer cast away by a union return type. Call sites in three pages, `AlgorithmVisualizer`, and `SearchVisualization` updated accordingly.
- Updates `GraphVisualization` to render arbitrary graphs: arrowheads when `directed`, weight labels on edges when any weight ≠ 1.
- Tests: graph algorithm suite now passes explicit graphs; new `sampleGraphs.test.ts` covers the builder, generators, and `defaultGraphFor`; `index.test.ts` updated for per-category lookups.

DFS/BFS/topological sort accept weighted graphs but ignore the weights — only Dijkstra reads them.

This is the foundation for Phase 2.5 (matrix / edge-list dual-view) and the new graph algorithms (A*, Prim's, Kruskal's), which are now unblocked.

## Test plan
- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 103/103 passing
- [x] `npm run build` clean
- [x] Browser smoke-test: Dijkstra page shows weighted edge labels; topological sort page shows directed arrowheads; DFS page renders the unweighted undirected graph; sorting & searching pages still load (200 OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)