### PR TITLE
Phase 4: custom input editing and shareable URLs

### DIFF
--- a/__tests__/lib/urlState.test.ts
+++ b/__tests__/lib/urlState.test.ts
@@ -1,0 +1,121 @@
+import {
+  parseArrayInput,
+  encodeUrlParams,
+  decodeUrlParams,
+} from "@/lib/urlState";
+
+describe("parseArrayInput", () => {
+  it("parses a valid comma-separated list", () => {
+    const result = parseArrayInput("5,10,23,8,42");
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([5, 10, 23, 8, 42]);
+  });
+
+  it("trims whitespace and handles spaces as separators", () => {
+    const result = parseArrayInput("  5 , 10 , 23 , 8 , 42  ");
+    expect(result.error).toBeNull();
+    expect(result.data).toEqual([5, 10, 23, 8, 42]);
+  });
+
+  it("accepts exactly 3 values (minimum)", () => {
+    const result = parseArrayInput("1,2,3");
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(3);
+  });
+
+  it("accepts exactly 25 values (maximum)", () => {
+    const input = Array.from({ length: 25 }, (_, i) => i + 1).join(",");
+    const result = parseArrayInput(input);
+    expect(result.error).toBeNull();
+    expect(result.data).toHaveLength(25);
+  });
+
+  it("returns error for fewer than 3 values", () => {
+    const result = parseArrayInput("5,10");
+    expect(result.error).not.toBeNull();
+    expect(result.data).toHaveLength(0);
+  });
+
+  it("returns error for more than 25 values", () => {
+    const input = Array.from({ length: 26 }, (_, i) => i + 1).join(",");
+    const result = parseArrayInput(input);
+    expect(result.error).not.toBeNull();
+    expect(result.data).toHaveLength(0);
+  });
+
+  it("returns error for non-numeric token", () => {
+    const result = parseArrayInput("5,abc,23");
+    expect(result.error).toContain("abc");
+    expect(result.data).toHaveLength(0);
+  });
+
+  it("returns error for value below minimum (0)", () => {
+    const result = parseArrayInput("0,5,10");
+    expect(result.error).not.toBeNull();
+  });
+
+  it("returns error for value above maximum (1000)", () => {
+    const result = parseArrayInput("5,1000,10");
+    expect(result.error).not.toBeNull();
+  });
+
+  it("returns error for floating point numbers", () => {
+    const result = parseArrayInput("5,10.5,23");
+    expect(result.error).not.toBeNull();
+  });
+
+  it("returns error for empty string", () => {
+    const result = parseArrayInput("");
+    expect(result.error).not.toBeNull();
+  });
+});
+
+describe("encodeUrlParams / decodeUrlParams round-trip", () => {
+  it("round-trips data and speed", () => {
+    const data = [5, 10, 23, 8, 42];
+    const speed = 7;
+    const params = encodeUrlParams({ data, speed });
+    const decoded = decodeUrlParams(params);
+    expect(decoded.data).toEqual(data);
+    expect(decoded.speed).toBe(speed);
+  });
+
+  it("round-trips target for searching", () => {
+    const params = encodeUrlParams({ data: [1, 2, 3], target: 22, speed: 5 });
+    const decoded = decodeUrlParams(params);
+    expect(decoded.target).toBe(22);
+  });
+
+  it("round-trips start vertex for graph", () => {
+    const params = encodeUrlParams({ start: 3, speed: 5 });
+    const decoded = decodeUrlParams(params);
+    expect(decoded.start).toBe(3);
+  });
+
+  it("returns undefined for missing keys", () => {
+    const decoded = decodeUrlParams(new URLSearchParams());
+    expect(decoded.data).toBeUndefined();
+    expect(decoded.target).toBeUndefined();
+    expect(decoded.start).toBeUndefined();
+    expect(decoded.speed).toBeUndefined();
+  });
+
+  it("ignores invalid data values silently", () => {
+    const params = new URLSearchParams("data=abc&speed=5");
+    const decoded = decodeUrlParams(params);
+    expect(decoded.data).toBeUndefined();
+    expect(decoded.speed).toBe(5);
+  });
+
+  it("ignores out-of-range speed", () => {
+    const params = new URLSearchParams("speed=99");
+    const decoded = decodeUrlParams(params);
+    expect(decoded.speed).toBeUndefined();
+  });
+
+  it("ignores negative start vertex", () => {
+    const params = new URLSearchParams("start=-1");
+    const decoded = decodeUrlParams(params);
+    expect(decoded.start).toBeUndefined();
+  });
+});

--- a/app/graph/[algorithm]/page.tsx
+++ b/app/graph/[algorithm]/page.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useEffect } from "react";
-import { useParams } from "next/navigation";
+import { Suspense, useEffect, useRef } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
 import { useAlgorithm } from "@/context/AlgorithmContext";
 import { getGraphAlgorithm, isGraphAlgorithm } from "@/lib/algorithms";
 import { defaultGraphFor } from "@/lib/algorithms/graph/sampleGraphs";
 import { availableAlgorithms } from "@/lib/algorithms/metadata";
+import { decodeUrlParams, encodeUrlParams } from "@/lib/urlState";
 
 function computeGraphViz(algorithmKey: string, target: number | undefined) {
   if (!isGraphAlgorithm(algorithmKey)) return { startVertex: 0, viz: null };
@@ -26,13 +27,27 @@ function computeGraphViz(algorithmKey: string, target: number | undefined) {
   }
 }
 
-export default function GraphPage() {
+function GraphPageInner() {
   const params = useParams();
   const algorithmKey = params.algorithm as string;
   const { dispatch, state } = useAlgorithm();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initializedFromUrl = useRef(false);
 
   const algorithmInfo = availableAlgorithms[algorithmKey];
 
+  // Initialize state from URL on first load
+  useEffect(() => {
+    if (initializedFromUrl.current) return;
+    initializedFromUrl.current = true;
+    const decoded = decodeUrlParams(searchParams);
+    if (decoded.start !== undefined)
+      dispatch({ type: "SET_TARGET", payload: decoded.start });
+    if (decoded.speed) dispatch({ type: "SET_SPEED", payload: decoded.speed });
+  }, [searchParams, dispatch]);
+
+  // Set algorithm and generate visualization when algorithm or start vertex changes
   useEffect(() => {
     if (!algorithmKey) return;
     dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
@@ -40,14 +55,16 @@ export default function GraphPage() {
     const { startVertex, viz } = computeGraphViz(algorithmKey, state.target);
     dispatch({ type: "SET_TARGET", payload: startVertex });
     if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
-  }, [
-    algorithmKey,
-    dispatch,
-    state.algorithm,
-    state.data,
-    state.visualizationData,
-    state.target,
-  ]);
+  }, [algorithmKey, dispatch, state.algorithm, state.data, state.visualizationData, state.target]);
+
+  // Keep URL in sync with current start vertex and speed
+  useEffect(() => {
+    const urlParams = encodeUrlParams({
+      ...(state.target !== undefined ? { start: state.target } : {}),
+      speed: state.speed,
+    });
+    router.replace(`?${urlParams.toString()}`, { scroll: false });
+  }, [state.target, state.speed, router]);
 
   if (!algorithmInfo) {
     return (
@@ -73,5 +90,13 @@ export default function GraphPage() {
     >
       <AlgorithmVisualizer />
     </PageLayout>
+  );
+}
+
+export default function GraphPage() {
+  return (
+    <Suspense>
+      <GraphPageInner />
+    </Suspense>
   );
 }

--- a/app/graph/[algorithm]/page.tsx
+++ b/app/graph/[algorithm]/page.tsx
@@ -55,7 +55,14 @@ function GraphPageInner() {
     const { startVertex, viz } = computeGraphViz(algorithmKey, state.target);
     dispatch({ type: "SET_TARGET", payload: startVertex });
     if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
-  }, [algorithmKey, dispatch, state.algorithm, state.data, state.visualizationData, state.target]);
+  }, [
+    algorithmKey,
+    dispatch,
+    state.algorithm,
+    state.data,
+    state.visualizationData,
+    state.target,
+  ]);
 
   // Keep URL in sync with current start vertex and speed
   useEffect(() => {

--- a/app/searching/[algorithm]/page.tsx
+++ b/app/searching/[algorithm]/page.tsx
@@ -1,57 +1,69 @@
 "use client";
 
-import { useEffect } from "react";
-import { useParams, notFound } from "next/navigation";
+import { Suspense, useEffect, useRef } from "react";
+import { useParams, useRouter, useSearchParams, notFound } from "next/navigation";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
 import { useAlgorithm } from "@/context/AlgorithmContext";
 import { getSearchAlgorithm } from "@/lib/algorithms";
 import { getRandomValueFromArray } from "@/lib/utils";
 import { availableAlgorithms } from "@/lib/algorithms/metadata";
+import { decodeUrlParams, encodeUrlParams } from "@/lib/urlState";
 
-export default function SearchingAlgorithmPage() {
+function SearchingPageInner() {
   const params = useParams();
   const algorithmKey = params.algorithm as string;
   const { dispatch, state } = useAlgorithm();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initializedFromUrl = useRef(false);
 
   const algorithmInfo = availableAlgorithms[algorithmKey];
 
-  // Set the current algorithm and generate visualization
+  // Initialize state from URL on first load
   useEffect(() => {
-    if (algorithmKey) {
-      dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
+    if (initializedFromUrl.current) return;
+    initializedFromUrl.current = true;
+    const decoded = decodeUrlParams(searchParams);
+    if (decoded.data) dispatch({ type: "SET_DATA", payload: decoded.data });
+    if (decoded.target) dispatch({ type: "SET_TARGET", payload: decoded.target });
+    if (decoded.speed) dispatch({ type: "SET_SPEED", payload: decoded.speed });
+  }, [searchParams, dispatch]);
 
-      // Generate a new target value if none exists or when algorithm changes
-      const target =
-        state.target ||
-        (state.data.length > 0 ? getRandomValueFromArray(state.data) : 42);
+  // Set algorithm and generate visualization when algorithm, data, or target changes
+  useEffect(() => {
+    if (!algorithmKey) return;
+    dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
 
-      dispatch({ type: "SET_TARGET", payload: target });
+    const target =
+      state.target ||
+      (state.data.length > 0 ? getRandomValueFromArray(state.data) : 42);
 
-      // For binary search, ensure the array is sorted and the target exists
-      const data = [...state.data];
+    dispatch({ type: "SET_TARGET", payload: target });
 
-      // Generate visualization if not already generated OR if algorithm changed
-      if (!state.visualizationData || algorithmKey !== state.algorithm) {
-        const algorithmFunction = getSearchAlgorithm(algorithmKey);
-        if (algorithmFunction) {
-          try {
-            const viz = algorithmFunction(data, target);
-            dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
-          } catch (error) {
-            console.error("Error generating visualization:", error);
-          }
+    if (!state.visualizationData || algorithmKey !== state.algorithm) {
+      const algorithmFunction = getSearchAlgorithm(algorithmKey);
+      if (algorithmFunction) {
+        try {
+          const data = [...state.data];
+          const viz = algorithmFunction(data, target);
+          dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+        } catch (error) {
+          console.error("Error generating visualization:", error);
         }
       }
     }
-  }, [
-    algorithmKey,
-    dispatch,
-    state.algorithm,
-    state.data,
-    state.visualizationData,
-    state.target,
-  ]);
+  }, [algorithmKey, dispatch, state.algorithm, state.data, state.visualizationData, state.target]);
+
+  // Keep URL in sync with current state
+  useEffect(() => {
+    const urlParams = encodeUrlParams({
+      data: state.data,
+      ...(state.target !== undefined ? { target: state.target } : {}),
+      speed: state.speed,
+    });
+    router.replace(`?${urlParams.toString()}`, { scroll: false });
+  }, [state.data, state.target, state.speed, router]);
 
   if (!algorithmInfo) {
     return notFound();
@@ -67,5 +79,13 @@ export default function SearchingAlgorithmPage() {
     >
       <AlgorithmVisualizer />
     </PageLayout>
+  );
+}
+
+export default function SearchingAlgorithmPage() {
+  return (
+    <Suspense>
+      <SearchingPageInner />
+    </Suspense>
   );
 }

--- a/app/searching/[algorithm]/page.tsx
+++ b/app/searching/[algorithm]/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { Suspense, useEffect, useRef } from "react";
-import { useParams, useRouter, useSearchParams, notFound } from "next/navigation";
+import {
+  useParams,
+  useRouter,
+  useSearchParams,
+  notFound,
+} from "next/navigation";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
 import { useAlgorithm } from "@/context/AlgorithmContext";
@@ -26,7 +31,8 @@ function SearchingPageInner() {
     initializedFromUrl.current = true;
     const decoded = decodeUrlParams(searchParams);
     if (decoded.data) dispatch({ type: "SET_DATA", payload: decoded.data });
-    if (decoded.target) dispatch({ type: "SET_TARGET", payload: decoded.target });
+    if (decoded.target)
+      dispatch({ type: "SET_TARGET", payload: decoded.target });
     if (decoded.speed) dispatch({ type: "SET_SPEED", payload: decoded.speed });
   }, [searchParams, dispatch]);
 
@@ -53,7 +59,14 @@ function SearchingPageInner() {
         }
       }
     }
-  }, [algorithmKey, dispatch, state.algorithm, state.data, state.visualizationData, state.target]);
+  }, [
+    algorithmKey,
+    dispatch,
+    state.algorithm,
+    state.data,
+    state.visualizationData,
+    state.target,
+  ]);
 
   // Keep URL in sync with current state
   useEffect(() => {

--- a/app/sorting/[algorithm]/page.tsx
+++ b/app/sorting/[algorithm]/page.tsx
@@ -1,41 +1,51 @@
 "use client";
 
-import React, { useEffect } from "react";
-import { useParams } from "next/navigation";
+import { Suspense, useEffect, useRef } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
 import { useAlgorithm } from "@/context/AlgorithmContext";
 import { getSortingAlgorithm } from "@/lib/algorithms";
 import { availableAlgorithms } from "@/lib/algorithms/metadata";
+import { decodeUrlParams, encodeUrlParams } from "@/lib/urlState";
 
-export default function AlgorithmPage() {
+function SortingPageInner() {
   const params = useParams();
   const algorithmKey = params.algorithm as string;
   const { dispatch, state } = useAlgorithm();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initializedFromUrl = useRef(false);
 
   const algorithmInfo = availableAlgorithms[algorithmKey];
 
-  // Set the current algorithm and generate visualization
+  // Initialize state from URL on first load
   useEffect(() => {
-    if (algorithmKey) {
-      dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
+    if (initializedFromUrl.current) return;
+    initializedFromUrl.current = true;
+    const decoded = decodeUrlParams(searchParams);
+    if (decoded.data) dispatch({ type: "SET_DATA", payload: decoded.data });
+    if (decoded.speed) dispatch({ type: "SET_SPEED", payload: decoded.speed });
+  }, [searchParams, dispatch]);
 
-      // Generate visualization if not already generated OR if algorithm changed
-      if (!state.visualizationData || algorithmKey !== state.algorithm) {
-        const algorithmFunction = getSortingAlgorithm(algorithmKey);
-        if (algorithmFunction) {
-          const viz = algorithmFunction(state.data);
-          dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
-        }
+  // Set algorithm and generate visualization when algorithm or data changes
+  useEffect(() => {
+    if (!algorithmKey) return;
+    dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
+    if (!state.visualizationData || algorithmKey !== state.algorithm) {
+      const algorithmFunction = getSortingAlgorithm(algorithmKey);
+      if (algorithmFunction) {
+        const viz = algorithmFunction(state.data);
+        dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
       }
     }
-  }, [
-    algorithmKey,
-    dispatch,
-    state.algorithm,
-    state.data,
-    state.visualizationData,
-  ]);
+  }, [algorithmKey, dispatch, state.algorithm, state.data, state.visualizationData]);
+
+  // Keep URL in sync with current state
+  useEffect(() => {
+    const urlParams = encodeUrlParams({ data: state.data, speed: state.speed });
+    router.replace(`?${urlParams.toString()}`, { scroll: false });
+  }, [state.data, state.speed, router]);
 
   if (!algorithmInfo) {
     return (
@@ -61,5 +71,13 @@ export default function AlgorithmPage() {
     >
       <AlgorithmVisualizer />
     </PageLayout>
+  );
+}
+
+export default function AlgorithmPage() {
+  return (
+    <Suspense>
+      <SortingPageInner />
+    </Suspense>
   );
 }

--- a/app/sorting/[algorithm]/page.tsx
+++ b/app/sorting/[algorithm]/page.tsx
@@ -39,7 +39,13 @@ function SortingPageInner() {
         dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
       }
     }
-  }, [algorithmKey, dispatch, state.algorithm, state.data, state.visualizationData]);
+  }, [
+    algorithmKey,
+    dispatch,
+    state.algorithm,
+    state.data,
+    state.visualizationData,
+  ]);
 
   // Keep URL in sync with current state
   useEffect(() => {

--- a/components/visualizer/AlgorithmVisualizer.tsx
+++ b/components/visualizer/AlgorithmVisualizer.tsx
@@ -7,6 +7,7 @@ import VisualizerControls from "./VisualizerControls";
 import AlgorithmInfo from "./AlgorithmInfo";
 import AlgorithmPseudocode from "./AlgorithmPseudocode";
 import ColorLegend from "./ColorLegend";
+import ArrayInputPanel from "./ArrayInputPanel";
 import { useAlgorithm } from "@/context/AlgorithmContext";
 import {
   getGraphAlgorithm,
@@ -15,6 +16,7 @@ import {
   isGraphAlgorithm,
 } from "@/lib/algorithms";
 import { defaultGraphFor } from "@/lib/algorithms/graph/sampleGraphs";
+import { generateRandomArray, getRandomValueFromArray } from "@/lib/utils";
 import type {
   AlgorithmVisualization,
   GraphStep,
@@ -22,14 +24,20 @@ import type {
   SortingStep,
 } from "@/lib/types";
 
-function regenerateGraph(algorithm: string): AlgorithmVisualization | null {
+function regenerateGraph(
+  algorithm: string,
+  startVertex?: number
+): AlgorithmVisualization | null {
   if (!isGraphAlgorithm(algorithm)) return null;
   const graphFn = getGraphAlgorithm(algorithm);
   if (!graphFn) return null;
   try {
     const graph = defaultGraphFor(algorithm);
-    const startVertex = Math.floor(Math.random() * graph.numVertices);
-    return graphFn(graph, startVertex);
+    const vertex =
+      startVertex !== undefined
+        ? startVertex
+        : Math.floor(Math.random() * graph.numVertices);
+    return graphFn(graph, vertex);
   } catch (error) {
     console.error("Error generating graph visualization:", error);
     return null;
@@ -72,22 +80,56 @@ export default function AlgorithmVisualizer() {
   const { currentStep, algorithm, data, visualizationData, target } = state;
   const category = visualizationData?.category ?? "";
 
-  const handleGenerateNewData = () => {
+  const numVertices =
+    category === "graph" && visualizationData
+      ? (visualizationData.steps[0] as GraphStep).graph.numVertices
+      : 6;
+
+  const handleRandomize = () => {
     if (category === "graph") {
-      const viz = regenerateGraph(algorithm);
+      const randomStart = Math.floor(Math.random() * numVertices);
+      dispatch({ type: "SET_TARGET", payload: randomStart });
+      const viz = regenerateGraph(algorithm, randomStart);
       if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
       return;
     }
 
-    dispatch({
-      type: "GENERATE_RANDOM_DATA",
-      payload: { min: 5, max: 95, length: 15 },
-    });
+    const newData = generateRandomArray(5, 95, 15);
+    dispatch({ type: "SET_DATA", payload: newData });
 
+    if (category === "searching") {
+      const newTarget = getRandomValueFromArray(newData);
+      dispatch({ type: "SET_TARGET", payload: newTarget });
+      const viz = regenerateSearch(algorithm, newData, newTarget);
+      if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+    } else {
+      const viz = regenerateSort(algorithm, newData);
+      if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+    }
+  };
+
+  const handleSetArray = (newData: number[]) => {
+    dispatch({ type: "SET_DATA", payload: newData });
+    const currentTarget = target ?? getRandomValueFromArray(newData);
+    if (target === undefined) {
+      dispatch({ type: "SET_TARGET", payload: currentTarget });
+    }
     const viz =
       category === "searching"
-        ? regenerateSearch(algorithm, state.data, target ?? 0)
-        : regenerateSort(algorithm, state.data);
+        ? regenerateSearch(algorithm, newData, currentTarget)
+        : regenerateSort(algorithm, newData);
+    if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+  };
+
+  const handleSetTarget = (newTarget: number) => {
+    dispatch({ type: "SET_TARGET", payload: newTarget });
+    const viz = regenerateSearch(algorithm, data, newTarget);
+    if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+  };
+
+  const handleSetStart = (start: number) => {
+    dispatch({ type: "SET_TARGET", payload: start });
+    const viz = regenerateGraph(algorithm, start);
     if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
   };
 
@@ -130,11 +172,18 @@ export default function AlgorithmVisualizer() {
             )}
           </div>
 
+          <ArrayInputPanel
+            category={category}
+            numVertices={numVertices}
+            onSetArray={handleSetArray}
+            onSetTarget={handleSetTarget}
+            onSetStart={handleSetStart}
+            onRandomize={handleRandomize}
+          />
+
           <VisualizerControls
             currentStep={currentStep}
             totalSteps={visualizationData.steps.length}
-            onGenerateNewArray={handleGenerateNewData}
-            algorithmCategory={category}
           />
 
           <ColorLegend

--- a/components/visualizer/ArrayInputPanel.tsx
+++ b/components/visualizer/ArrayInputPanel.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useAlgorithm } from "@/context/AlgorithmContext";
+import { parseArrayInput } from "@/lib/urlState";
+
+interface ArrayInputPanelProps {
+  category: string;
+  numVertices?: number;
+  onSetArray: (data: number[]) => void;
+  onSetTarget: (target: number) => void;
+  onSetStart: (start: number) => void;
+  onRandomize: () => void;
+}
+
+function FieldError({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <p className="text-sm text-red-600" role="alert">
+      {message}
+    </p>
+  );
+}
+
+export default function ArrayInputPanel({
+  category,
+  numVertices = 6,
+  onSetArray,
+  onSetTarget,
+  onSetStart,
+  onRandomize,
+}: ArrayInputPanelProps) {
+  const { state } = useAlgorithm();
+  const { data, target } = state;
+
+  const [arrayDraft, setArrayDraft] = useState(data.join(", "));
+  const [arrayError, setArrayError] = useState<string | null>(null);
+  const [targetDraft, setTargetDraft] = useState(target !== undefined ? String(target) : "");
+  const [targetError, setTargetError] = useState<string | null>(null);
+  const [startDraft, setStartDraft] = useState(target !== undefined ? String(target) : "0");
+  const [startError, setStartError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setArrayDraft(data.join(", "));
+    setArrayError(null);
+  }, [data]);
+
+  useEffect(() => {
+    if (target !== undefined) {
+      setTargetDraft(String(target));
+      setTargetError(null);
+      setStartDraft(String(target));
+      setStartError(null);
+    }
+  }, [target]);
+
+  const handleSetArray = () => {
+    const result = parseArrayInput(arrayDraft);
+    if (result.error) return setArrayError(result.error);
+    setArrayError(null);
+    onSetArray(result.data);
+  };
+
+  const handleSetTarget = () => {
+    const n = Number(targetDraft.trim());
+    if (!Number.isInteger(n) || isNaN(n) || n < 1 || n > 999)
+      return setTargetError("Enter a whole number between 1 and 999.");
+    setTargetError(null);
+    onSetTarget(n);
+  };
+
+  const handleSetStart = () => {
+    const n = Number(startDraft.trim());
+    if (!Number.isInteger(n) || isNaN(n) || n < 0 || n >= numVertices)
+      return setStartError(`Enter a vertex index between 0 and ${numVertices - 1}.`);
+    setStartError(null);
+    onSetStart(n);
+  };
+
+  if (category === "graph") {
+    return (
+      <div className="card space-y-4 p-6">
+        <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+          Graph Options
+        </h3>
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700">
+            Start Vertex (0–{numVertices - 1})
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              min={0}
+              max={numVertices - 1}
+              value={startDraft}
+              onChange={(e) => { setStartDraft(e.target.value); setStartError(null); }}
+              onKeyDown={(e) => e.key === "Enter" && handleSetStart()}
+              className="w-24 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              aria-label="Start vertex"
+            />
+            <button onClick={handleSetStart} className="btn btn-primary">Set</button>
+            <button onClick={onRandomize} className="btn btn-secondary">Randomize</button>
+          </div>
+          <FieldError message={startError} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="card space-y-4 p-6">
+      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+        Input Data
+      </h3>
+      <div className="flex flex-col gap-2">
+        <label className="text-sm font-medium text-gray-700">
+          Array (3–25 integers, 1–999, comma-separated)
+        </label>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={arrayDraft}
+            onChange={(e) => { setArrayDraft(e.target.value); setArrayError(null); }}
+            onKeyDown={(e) => e.key === "Enter" && handleSetArray()}
+            placeholder="e.g. 5, 10, 23, 8, 42"
+            className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            aria-label="Array input"
+          />
+          <button onClick={handleSetArray} className="btn btn-primary">Set</button>
+          <button onClick={onRandomize} className="btn btn-secondary">Randomize</button>
+        </div>
+        <FieldError message={arrayError} />
+      </div>
+      {category === "searching" && (
+        <div className="flex flex-col gap-2">
+          <label className="text-sm font-medium text-gray-700">
+            Search Target (1–999)
+          </label>
+          <div className="flex gap-2">
+            <input
+              type="number"
+              min={1}
+              max={999}
+              value={targetDraft}
+              onChange={(e) => { setTargetDraft(e.target.value); setTargetError(null); }}
+              onKeyDown={(e) => e.key === "Enter" && handleSetTarget()}
+              className="w-28 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+              aria-label="Search target"
+            />
+            <button onClick={handleSetTarget} className="btn btn-primary">Set</button>
+          </div>
+          <FieldError message={targetError} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/visualizer/ArrayInputPanel.tsx
+++ b/components/visualizer/ArrayInputPanel.tsx
@@ -35,9 +35,13 @@ export default function ArrayInputPanel({
 
   const [arrayDraft, setArrayDraft] = useState(data.join(", "));
   const [arrayError, setArrayError] = useState<string | null>(null);
-  const [targetDraft, setTargetDraft] = useState(target !== undefined ? String(target) : "");
+  const [targetDraft, setTargetDraft] = useState(
+    target !== undefined ? String(target) : ""
+  );
   const [targetError, setTargetError] = useState<string | null>(null);
-  const [startDraft, setStartDraft] = useState(target !== undefined ? String(target) : "0");
+  const [startDraft, setStartDraft] = useState(
+    target !== undefined ? String(target) : "0"
+  );
   const [startError, setStartError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -72,7 +76,9 @@ export default function ArrayInputPanel({
   const handleSetStart = () => {
     const n = Number(startDraft.trim());
     if (!Number.isInteger(n) || isNaN(n) || n < 0 || n >= numVertices)
-      return setStartError(`Enter a vertex index between 0 and ${numVertices - 1}.`);
+      return setStartError(
+        `Enter a vertex index between 0 and ${numVertices - 1}.`
+      );
     setStartError(null);
     onSetStart(n);
   };
@@ -80,7 +86,7 @@ export default function ArrayInputPanel({
   if (category === "graph") {
     return (
       <div className="card space-y-4 p-6">
-        <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+        <h3 className="text-sm font-semibold tracking-wide text-gray-700 uppercase">
           Graph Options
         </h3>
         <div className="flex flex-col gap-2">
@@ -93,13 +99,20 @@ export default function ArrayInputPanel({
               min={0}
               max={numVertices - 1}
               value={startDraft}
-              onChange={(e) => { setStartDraft(e.target.value); setStartError(null); }}
+              onChange={(e) => {
+                setStartDraft(e.target.value);
+                setStartError(null);
+              }}
               onKeyDown={(e) => e.key === "Enter" && handleSetStart()}
               className="w-24 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
               aria-label="Start vertex"
             />
-            <button onClick={handleSetStart} className="btn btn-primary">Set</button>
-            <button onClick={onRandomize} className="btn btn-secondary">Randomize</button>
+            <button onClick={handleSetStart} className="btn btn-primary">
+              Set
+            </button>
+            <button onClick={onRandomize} className="btn btn-secondary">
+              Randomize
+            </button>
           </div>
           <FieldError message={startError} />
         </div>
@@ -109,7 +122,7 @@ export default function ArrayInputPanel({
 
   return (
     <div className="card space-y-4 p-6">
-      <h3 className="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+      <h3 className="text-sm font-semibold tracking-wide text-gray-700 uppercase">
         Input Data
       </h3>
       <div className="flex flex-col gap-2">
@@ -120,14 +133,21 @@ export default function ArrayInputPanel({
           <input
             type="text"
             value={arrayDraft}
-            onChange={(e) => { setArrayDraft(e.target.value); setArrayError(null); }}
+            onChange={(e) => {
+              setArrayDraft(e.target.value);
+              setArrayError(null);
+            }}
             onKeyDown={(e) => e.key === "Enter" && handleSetArray()}
             placeholder="e.g. 5, 10, 23, 8, 42"
             className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
             aria-label="Array input"
           />
-          <button onClick={handleSetArray} className="btn btn-primary">Set</button>
-          <button onClick={onRandomize} className="btn btn-secondary">Randomize</button>
+          <button onClick={handleSetArray} className="btn btn-primary">
+            Set
+          </button>
+          <button onClick={onRandomize} className="btn btn-secondary">
+            Randomize
+          </button>
         </div>
         <FieldError message={arrayError} />
       </div>
@@ -142,12 +162,17 @@ export default function ArrayInputPanel({
               min={1}
               max={999}
               value={targetDraft}
-              onChange={(e) => { setTargetDraft(e.target.value); setTargetError(null); }}
+              onChange={(e) => {
+                setTargetDraft(e.target.value);
+                setTargetError(null);
+              }}
               onKeyDown={(e) => e.key === "Enter" && handleSetTarget()}
               className="w-28 rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
               aria-label="Search target"
             />
-            <button onClick={handleSetTarget} className="btn btn-primary">Set</button>
+            <button onClick={handleSetTarget} className="btn btn-primary">
+              Set
+            </button>
           </div>
           <FieldError message={targetError} />
         </div>

--- a/components/visualizer/VisualizerControls.tsx
+++ b/components/visualizer/VisualizerControls.tsx
@@ -1,12 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import { useAlgorithm } from "@/context/AlgorithmContext";
 
 interface VisualizerControlsProps {
   currentStep: number;
   totalSteps: number;
-  onGenerateNewArray: () => void;
-  algorithmCategory?: string;
 }
 
 const PrevIcon = (
@@ -98,11 +97,17 @@ const ResetIcon = (
 export default function VisualizerControls({
   currentStep,
   totalSteps,
-  onGenerateNewArray,
-  algorithmCategory = "sorting",
 }: VisualizerControlsProps) {
   const { state, dispatch } = useAlgorithm();
   const { isPlaying, speed } = state;
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = () => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
 
   const handlePlay = () => dispatch({ type: "SET_IS_PLAYING", payload: true });
   const handlePause = () =>
@@ -114,9 +119,6 @@ export default function VisualizerControls({
     dispatch({ type: "SET_SPEED", payload: parseInt(e.target.value) });
   const handleStepChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     dispatch({ type: "SET_CURRENT_STEP", payload: parseInt(e.target.value) });
-
-  const newDataButtonText =
-    algorithmCategory === "graph" ? "New Graph" : "New Array";
 
   return (
     <div className="card space-y-6 p-6">
@@ -201,25 +203,20 @@ export default function VisualizerControls({
       </div>
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="flex items-center space-x-4">
-          <button
-            onClick={handleReset}
-            className="btn btn-secondary flex w-full cursor-pointer items-center justify-center space-x-2"
-          >
-            {ResetIcon}
-            <span>Reset</span>
-          </button>
-        </div>
+        <button
+          onClick={handleReset}
+          className="btn btn-secondary flex w-full cursor-pointer items-center justify-center space-x-2"
+        >
+          {ResetIcon}
+          <span>Reset</span>
+        </button>
 
-        <div>
-          <button
-            onClick={onGenerateNewArray}
-            className="btn btn-primary flex w-full cursor-pointer items-center justify-center space-x-2 bg-purple-500 hover:bg-purple-600"
-          >
-            {ResetIcon}
-            <span>{newDataButtonText}</span>
-          </button>
-        </div>
+        <button
+          onClick={handleShare}
+          className="btn btn-primary flex w-full cursor-pointer items-center justify-center space-x-2 bg-purple-500 hover:bg-purple-600"
+        >
+          <span>{copied ? "Copied!" : "Share"}</span>
+        </button>
       </div>
     </div>
   );

--- a/lib/urlState.ts
+++ b/lib/urlState.ts
@@ -1,0 +1,110 @@
+const ARRAY_MIN_LENGTH = 3;
+const ARRAY_MAX_LENGTH = 25;
+const VALUE_MIN = 1;
+const VALUE_MAX = 999;
+const SPEED_MIN = 1;
+const SPEED_MAX = 10;
+
+export interface ParseResult {
+  data: number[];
+  error: string | null;
+}
+
+export function parseArrayInput(raw: string): ParseResult {
+  const tokens = raw
+    .trim()
+    .split(/[\s,]+/)
+    .filter((t) => t.length > 0);
+
+  if (tokens.length < ARRAY_MIN_LENGTH) {
+    return {
+      data: [],
+      error: `Enter at least ${ARRAY_MIN_LENGTH} numbers.`,
+    };
+  }
+  if (tokens.length > ARRAY_MAX_LENGTH) {
+    return {
+      data: [],
+      error: `Enter at most ${ARRAY_MAX_LENGTH} numbers.`,
+    };
+  }
+
+  const data: number[] = [];
+  for (const token of tokens) {
+    const n = Number(token);
+    if (!Number.isInteger(n) || isNaN(n)) {
+      return { data: [], error: `"${token}" is not a valid integer.` };
+    }
+    if (n < VALUE_MIN || n > VALUE_MAX) {
+      return {
+        data: [],
+        error: `Values must be between ${VALUE_MIN} and ${VALUE_MAX}.`,
+      };
+    }
+    data.push(n);
+  }
+
+  return { data, error: null };
+}
+
+interface EncodeOptions {
+  data?: number[];
+  target?: number;
+  start?: number;
+  speed: number;
+}
+
+export function encodeUrlParams(opts: EncodeOptions): URLSearchParams {
+  const params = new URLSearchParams();
+  if (opts.data && opts.data.length > 0) {
+    params.set("data", opts.data.join(","));
+  }
+  if (opts.target !== undefined) {
+    params.set("target", String(opts.target));
+  }
+  if (opts.start !== undefined) {
+    params.set("start", String(opts.start));
+  }
+  params.set("speed", String(opts.speed));
+  return params;
+}
+
+interface DecodedState {
+  data?: number[];
+  target?: number;
+  start?: number;
+  speed?: number;
+}
+
+function parseIntParam(
+  params: URLSearchParams,
+  key: string,
+  min: number,
+  max: number
+): number | undefined {
+  const raw = params.get(key);
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= min && n <= max ? n : undefined;
+}
+
+export function decodeUrlParams(params: URLSearchParams): DecodedState {
+  const result: DecodedState = {};
+
+  const rawData = params.get("data");
+  if (rawData) {
+    const parsed = parseArrayInput(rawData);
+    if (!parsed.error) result.data = parsed.data;
+  }
+
+  const target = parseIntParam(params, "target", VALUE_MIN, VALUE_MAX);
+  if (target !== undefined) result.target = target;
+
+  const start = parseIntParam(params, "start", 0, Number.MAX_SAFE_INTEGER);
+  if (start !== undefined) result.start = start;
+
+  const speed = parseIntParam(params, "speed", SPEED_MIN, SPEED_MAX);
+  if (speed !== undefined) result.speed = speed;
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- **Custom array input** — sorting and searching pages now have a text field where users can type their own comma-separated integers (3–25 values, each 1–999) with inline validation and an error message
- **Custom target / start vertex** — searching pages expose a target number field; graph pages expose a start vertex selector (0 to numVertices−1)
- **Shareable URLs** — every algorithm page encodes its current data, target/start, and speed into query params (`?data=5,10,23&target=22&speed=7`); pasting a URL restores the exact state
- **Share button** — replaces the old "New Array" button with a Share button that copies the current URL to clipboard and flashes "Copied!"
- **Randomize** — moved from VisualizerControls into the new ArrayInputPanel so it sits next to the input fields

## What changed

| File | Change |
|------|--------|
| `lib/urlState.ts` | New pure utility: `parseArrayInput`, `encodeUrlParams`, `decodeUrlParams` |
| `components/visualizer/ArrayInputPanel.tsx` | New input card component with validation |
| `components/visualizer/AlgorithmVisualizer.tsx` | Wires ArrayInputPanel; handles all mutation callbacks |
| `components/visualizer/VisualizerControls.tsx` | Removed "New Array" prop; added Share button |
| `app/sorting/[algorithm]/page.tsx` | URL read-on-mount + sync-on-change; wrapped in Suspense |
| `app/searching/[algorithm]/page.tsx` | Same + target param |
| `app/graph/[algorithm]/page.tsx` | URL sync for start vertex and speed only |
| `__tests__/lib/urlState.test.ts` | 17 unit tests (happy path, boundaries, invalid inputs) |

## Notes for reviewer

- Graph topology is intentionally not editable in this phase — that belongs with Phase 8 (grid pathfinding). Only the start vertex is URL-encoded for graphs.
- `useSearchParams()` requires a Suspense boundary in Next.js 15; each page is split into an outer default export (wraps in `<Suspense>`) and an inner component that uses the hook.
- URL sync uses `router.replace` (not `push`) to avoid polluting browser history as data changes.
- All CI checks pass: lint ✓ · tsc ✓ · build ✓ · 121 tests ✓

🤖 Generated with [Claude Code](https://claude.ai/claude-code)