### PR TITLE
Phases 5-7: visual primitives, data structures, dynamic programming

### DIFF
--- a/GROWTH.md
+++ b/GROWTH.md
@@ -12,6 +12,80 @@ Copy the template at the bottom of this file, fill it in, and prepend it to the 
 
 ## Snapshots
 
+### 2026-05-10 — After Phases 6 & 7: data structures and DP on the new primitives
+
+**Trigger:** Phase 6 data structures (BST insert, min-heap insert) and Phase 7 dynamic programming (Edit Distance, LCS) layered on top of the Phase 5 visual-primitives architecture. Two new primitives — TreeShape and Grid2D — extend the existing array-bars / array-cells / graph-2d set.
+
+#### Algorithms
+
+| Category        | Count  | Names                                                                    |
+| --------------- | ------ | ------------------------------------------------------------------------ |
+| Sorting         | 6      | bubbleSort, selectionSort, insertionSort, mergeSort, quickSort, heapSort |
+| Searching       | 2      | linearSearch, binarySearch                                               |
+| Graph           | 7      | bfs, dfs, dijkstra, topologicalSort, bellmanFord, prim, kruskal          |
+| Data Structures | 2      | bstInsert, minHeapInsert                                                 |
+| Dynamic Prog.   | 2      | editDistance, lcs                                                        |
+| **Total**       | **19** |                                                                          |
+
+Difficulty breakdown: easy × 4, medium × 11, hard × 4
+
+#### Test suite
+
+| Metric             | Count  |
+| ------------------ | ------ |
+| Test files         | 14     |
+| Test cases         | 162    |
+| Statement coverage | 57.35% |
+| Branch coverage    | 42.62% |
+| Function coverage  | 46.15% |
+
+New test files:
+
+- `__tests__/lib/algorithms/datastructure/bst.test.ts` — BST insertion, in-order property, duplicates, lineNumber annotations
+- `__tests__/lib/algorithms/datastructure/heap.test.ts` — min-heap invariant, no input mutation, lineNumber annotations
+- `__tests__/lib/algorithms/dp/dp.test.ts` — Edit Distance and LCS correctness across canonical pairs
+
+#### Pages & routes
+
+| Metric           | Count  |
+| ---------------- | ------ |
+| Static routes    | 8      |
+| Dynamic routes   | 8      |
+| **Total routes** | **16** |
+
+New routes: `/datastructure`, `/datastructure/[algorithm]`, `/dp`, `/dp/[algorithm]`. Sitemap updated.
+
+#### Components
+
+| Metric                | Count |
+| --------------------- | ----- |
+| Total components      | 21    |
+| Visualizer primitives | 5     |
+
+New primitives in `components/primitives/`:
+
+- `TreeShape.tsx` — binary tree SVG layout, BFS coloring per `TreeStep`
+- `Grid2D.tsx` — DP-table grid with row/col labels, dependency highlights, traceback path
+
+New input panel: `components/visualizer/StringPairInputPanel.tsx` — two-string input for DP algorithms.
+
+`renderPrimitive`'s exhaustive switch now covers all five primitives.
+
+#### Source code
+
+| Metric                                   | Count  |
+| ---------------------------------------- | ------ |
+| TypeScript/TSX files                     | 76     |
+| Total lines (lib+components+context+app) | ~8,457 |
+
+#### Notes
+
+- **Discriminated primitives:** new algorithms declare `primitive: "tree-shape"` or `"grid-2d"` and the `StepsForPrimitive` mapped type constrains their step shape at the `createVisualization` call site.
+- **DP input model:** DP page maintains its own `(stringA, stringB)` state independent of the global `data: number[]`. Strings are URL-synced as `?a=…&b=…`.
+- **Categories:** added `dp` to `AlgorithmCategory`. Home page now uses an explicit label map and category ordering rather than auto-titlecasing the category key.
+
+---
+
 ### 2026-05-09 — After Phase 3 & 4: Graph algorithms + test expansion
 
 **Trigger:** Addition of Bellman-Ford, Prim's, Kruskal's algorithms; Phase 4 custom input editing & shareable URLs; comprehensive test suite expansion.

--- a/GROWTH.md
+++ b/GROWTH.md
@@ -92,26 +92,27 @@ New input panel: `components/visualizer/StringPairInputPanel.tsx` — two-string
 
 #### Algorithms
 
-| Category   | Count | Names |
-|------------|-------|-------|
-| Sorting    | 6     | bubbleSort, selectionSort, insertionSort, mergeSort, quickSort, heapSort |
-| Searching  | 2     | linearSearch, binarySearch |
-| Graph      | 7     | bfs, dfs, dijkstra, topologicalSort, bellmanFord, prim, kruskal |
-| **Total**  | **15** | |
+| Category  | Count  | Names                                                                    |
+| --------- | ------ | ------------------------------------------------------------------------ |
+| Sorting   | 6      | bubbleSort, selectionSort, insertionSort, mergeSort, quickSort, heapSort |
+| Searching | 2      | linearSearch, binarySearch                                               |
+| Graph     | 7      | bfs, dfs, dijkstra, topologicalSort, bellmanFord, prim, kruskal          |
+| **Total** | **15** |                                                                          |
 
 Difficulty breakdown: easy × 4, medium × 8, hard × 3
 
 #### Test suite
 
-| Metric | Count |
-|--------|-------|
-| Test files | 11 |
-| Test cases | 134 |
+| Metric             | Count  |
+| ------------------ | ------ |
+| Test files         | 11     |
+| Test cases         | 134    |
 | Statement coverage | 57.17% |
-| Branch coverage | 44.73% |
-| Function coverage | 42.55% |
+| Branch coverage    | 44.73% |
+| Function coverage  | 42.55% |
 
 Test files:
+
 - `__tests__/lib/utils.test.ts` — 2 cases
 - `__tests__/lib/algorithms/index.test.ts` — 4 cases
 - `__tests__/lib/algorithms/sorting/bubbleSort.test.ts` — 6 cases
@@ -126,29 +127,29 @@ Test files:
 
 #### Pages & routes
 
-| Metric | Count |
-|--------|-------|
-| Static routes | 6 |
-| Dynamic routes | 6 |
+| Metric           | Count  |
+| ---------------- | ------ |
+| Static routes    | 6      |
+| Dynamic routes   | 6      |
 | **Total routes** | **12** |
 
 Routes unchanged from baseline; all new algorithms available via existing route structure.
 
 #### Components
 
-| Metric | Count |
-|--------|-------|
-| Total components | 17 |
-| Visualizer components | 10 |
+| Metric                | Count |
+| --------------------- | ----- |
+| Total components      | 17    |
+| Visualizer components | 10    |
 
 New components: InputPanel, graphEdge (support for custom input editing and graph visualization).
 
 #### Source code
 
-| Metric | Count |
-|--------|-------|
-| TypeScript/TSX files | 75 |
-| Total lines | ~7,879 |
+| Metric               | Count  |
+| -------------------- | ------ |
+| TypeScript/TSX files | 75     |
+| Total lines          | ~7,879 |
 
 #### Notes
 
@@ -165,24 +166,25 @@ New components: InputPanel, graphEdge (support for custom input editing and grap
 
 #### Algorithms
 
-| Category   | Count | Names |
-|------------|-------|-------|
-| Sorting    | 6     | bubbleSort, selectionSort, insertionSort, mergeSort, quickSort, heapSort |
-| Searching  | 2     | linearSearch, binarySearch |
-| Graph      | 4     | bfs, dfs, dijkstra, topologicalSort |
-| **Total**  | **12** | |
+| Category  | Count  | Names                                                                    |
+| --------- | ------ | ------------------------------------------------------------------------ |
+| Sorting   | 6      | bubbleSort, selectionSort, insertionSort, mergeSort, quickSort, heapSort |
+| Searching | 2      | linearSearch, binarySearch                                               |
+| Graph     | 4      | bfs, dfs, dijkstra, topologicalSort                                      |
+| **Total** | **12** |                                                                          |
 
 Difficulty breakdown: easy × 4, medium × 6, hard × 2
 
 #### Test suite
 
-| Metric | Count |
-|--------|-------|
-| Test files | 7 |
-| Test cases | 56 |
+| Metric                   | Count                      |
+| ------------------------ | -------------------------- |
+| Test files               | 7                          |
+| Test cases               | 56                         |
 | Files with zero coverage | ~50 (components, most lib) |
 
 Test files:
+
 - `__tests__/lib/utils.test.ts` — 2 cases
 - `__tests__/lib/algorithms/index.test.ts` — 4 cases
 - `__tests__/lib/algorithms/sorting/bubbleSort.test.ts` — 6 cases
@@ -193,51 +195,51 @@ Test files:
 
 #### Pages & routes (`app/`)
 
-| Route | Type |
-|-------|------|
-| `/` | Static |
-| `/about` | Static |
-| `/difficulty` | Static |
+| Route                      | Type    |
+| -------------------------- | ------- |
+| `/`                        | Static  |
+| `/about`                   | Static  |
+| `/difficulty`              | Static  |
 | `/difficulty/[difficulty]` | Dynamic |
-| `/glossary` | Static |
-| `/glossary/[term]` | Dynamic |
-| `/sorting` | Static |
-| `/sorting/[algorithm]` | Dynamic |
-| `/searching` | Static |
-| `/searching/[algorithm]` | Dynamic |
-| `/graph` | Static |
-| `/graph/[algorithm]` | Dynamic |
+| `/glossary`                | Static  |
+| `/glossary/[term]`         | Dynamic |
+| `/sorting`                 | Static  |
+| `/sorting/[algorithm]`     | Dynamic |
+| `/searching`               | Static  |
+| `/searching/[algorithm]`   | Dynamic |
+| `/graph`                   | Static  |
+| `/graph/[algorithm]`       | Dynamic |
 
 **Total routes: 12** (6 static + 6 dynamic)
 
 #### Components (`components/`)
 
-| Directory | Components |
-|-----------|------------|
-| `components/` (root) | AlgorithmCard, Controls |
-| `components/glossary/` | GlossaryItem |
-| `components/layout/` | Footer, Navbar, PageLayout |
-| `components/seo/` | JsonLd |
+| Directory                | Components                                                                                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components/` (root)     | AlgorithmCard, Controls                                                                                                                                 |
+| `components/glossary/`   | GlossaryItem                                                                                                                                            |
+| `components/layout/`     | Footer, Navbar, PageLayout                                                                                                                              |
+| `components/seo/`        | JsonLd                                                                                                                                                  |
 | `components/visualizer/` | AlgorithmInfo, AlgorithmPseudocode, AlgorithmVisualizer, ColorLegend, GraphVisualization, SearchVisualization, SortingVisualization, VisualizerControls |
 
 **Total components: 15**
 
 #### Source code
 
-| Metric | Count |
-|--------|-------|
-| TypeScript/TSX files | 69 |
-| Total lines (all `.ts`/`.tsx`) | ~6,550 |
-| Type definitions (`lib/types.ts`) | 8 |
-| Step types | 3 (SortingStep, SearchStep, GraphStep) |
+| Metric                            | Count                                  |
+| --------------------------------- | -------------------------------------- |
+| TypeScript/TSX files              | 69                                     |
+| Total lines (all `.ts`/`.tsx`)    | ~6,550                                 |
+| Type definitions (`lib/types.ts`) | 8                                      |
+| Step types                        | 3 (SortingStep, SearchStep, GraphStep) |
 
 #### Dependencies
 
-| Type | Count |
-|------|-------|
-| Production | 3 (next, react, react-dom) |
-| Development | 23 |
-| **Total** | **26** |
+| Type        | Count                      |
+| ----------- | -------------------------- |
+| Production  | 3 (next, react, react-dom) |
+| Development | 23                         |
+| **Total**   | **26**                     |
 
 ---
 
@@ -252,45 +254,45 @@ Copy and fill in for each new snapshot:
 
 #### Algorithms
 
-| Category   | Count | Names |
-|------------|-------|-------|
-| Sorting    |       | |
-| Searching  |       | |
-| Graph      |       | |
-| **Total**  |       | |
+| Category  | Count | Names |
+| --------- | ----- | ----- |
+| Sorting   |       |       |
+| Searching |       |       |
+| Graph     |       |       |
+| **Total** |       |       |
 
 Difficulty breakdown: easy × ?, medium × ?, hard × ?
 
 #### Test suite
 
-| Metric | Count |
-|--------|-------|
-| Test files | |
-| Test cases | |
-| Statement coverage | |
-| Branch coverage | |
+| Metric             | Count |
+| ------------------ | ----- |
+| Test files         |       |
+| Test cases         |       |
+| Statement coverage |       |
+| Branch coverage    |       |
 
 #### Pages & routes
 
-| Metric | Count |
-|--------|-------|
-| Static routes | |
-| Dynamic routes | |
-| **Total routes** | |
+| Metric           | Count |
+| ---------------- | ----- |
+| Static routes    |       |
+| Dynamic routes   |       |
+| **Total routes** |       |
 
 #### Components
 
-| Metric | Count |
-|--------|-------|
-| Total components | |
-| Visualizer components | |
+| Metric                | Count |
+| --------------------- | ----- |
+| Total components      |       |
+| Visualizer components |       |
 
 #### Source code
 
-| Metric | Count |
-|--------|-------|
-| TypeScript/TSX files | |
-| Total lines | |
+| Metric               | Count |
+| -------------------- | ----- |
+| TypeScript/TSX files |       |
+| Total lines          |       |
 
 #### Notes
 

--- a/__tests__/lib/algorithms/datastructure/bst.test.ts
+++ b/__tests__/lib/algorithms/datastructure/bst.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { bstInsert } from "@/lib/algorithms/datastructure/bst";
+import type { BinaryTreeNode, TreeStep } from "@/lib/types";
+
+function lastStep(values: number[]): TreeStep {
+  const viz = bstInsert(values);
+  return viz.steps[viz.steps.length - 1] as TreeStep;
+}
+
+function inOrder(nodes: BinaryTreeNode[], rootId: number | null): number[] {
+  if (rootId === null) return [];
+  const map = new Map(nodes.map((n) => [n.id, n]));
+  const out: number[] = [];
+  const walk = (id: number | null): void => {
+    if (id === null) return;
+    const n = map.get(id);
+    if (!n) return;
+    walk(n.left);
+    out.push(n.value);
+    walk(n.right);
+  };
+  walk(rootId);
+  return out;
+}
+
+describe("bstInsert", () => {
+  it("returns metadata", () => {
+    const viz = bstInsert([5, 3, 8]);
+    expect(viz.key).toBe("bstInsert");
+    expect(viz.category).toBe("datastructure");
+    expect(viz.primitive).toBe("tree-shape");
+    expect(viz.steps.length).toBeGreaterThan(0);
+    expect(viz.timeComplexity).toBeTruthy();
+  });
+
+  it("produces an empty tree for empty input", () => {
+    const step = lastStep([]);
+    expect(step.nodes).toEqual([]);
+    expect(step.rootId).toBeNull();
+  });
+
+  it("places the first value at the root", () => {
+    const step = lastStep([42]);
+    expect(step.rootId).not.toBeNull();
+    expect(step.nodes).toHaveLength(1);
+    expect(step.nodes[0]!.value).toBe(42);
+  });
+
+  it("yields sorted in-order traversal", () => {
+    const step = lastStep([5, 3, 8, 1, 4, 7, 9]);
+    expect(inOrder(step.nodes, step.rootId)).toEqual([1, 3, 4, 5, 7, 8, 9]);
+  });
+
+  it("places smaller values to the left and larger to the right", () => {
+    const step = lastStep([5, 3, 8]);
+    const root = step.nodes.find((n) => n.id === step.rootId)!;
+    const left = step.nodes.find((n) => n.id === root.left)!;
+    const right = step.nodes.find((n) => n.id === root.right)!;
+    expect(root.value).toBe(5);
+    expect(left.value).toBe(3);
+    expect(right.value).toBe(8);
+  });
+
+  it("skips duplicates", () => {
+    const step = lastStep([5, 5, 5]);
+    expect(step.nodes).toHaveLength(1);
+  });
+
+  it("annotates each step with a lineNumber", () => {
+    const viz = bstInsert([5, 3]);
+    for (const step of viz.steps) {
+      expect("lineNumber" in step).toBe(true);
+    }
+  });
+});

--- a/__tests__/lib/algorithms/datastructure/heap.test.ts
+++ b/__tests__/lib/algorithms/datastructure/heap.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { minHeapInsert } from "@/lib/algorithms/datastructure/heap";
+import type { TreeStep } from "@/lib/types";
+
+function lastStep(values: number[]): TreeStep {
+  const viz = minHeapInsert(values);
+  return viz.steps[viz.steps.length - 1] as TreeStep;
+}
+
+function heapValues(step: TreeStep): number[] {
+  return step.nodes.map((n) => n.value);
+}
+
+function isMinHeap(values: number[]): boolean {
+  for (let i = 0; i < values.length; i++) {
+    const left = 2 * i + 1;
+    const right = 2 * i + 2;
+    if (left < values.length && values[i]! > values[left]!) return false;
+    if (right < values.length && values[i]! > values[right]!) return false;
+  }
+  return true;
+}
+
+describe("minHeapInsert", () => {
+  it("returns metadata", () => {
+    const viz = minHeapInsert([3, 1, 2]);
+    expect(viz.key).toBe("minHeapInsert");
+    expect(viz.category).toBe("datastructure");
+    expect(viz.primitive).toBe("tree-shape");
+    expect(viz.steps.length).toBeGreaterThan(0);
+  });
+
+  it("produces an empty heap for empty input", () => {
+    const step = lastStep([]);
+    expect(step.nodes).toEqual([]);
+    expect(step.rootId).toBeNull();
+  });
+
+  it("maintains the min-heap invariant", () => {
+    const step = lastStep([5, 2, 8, 1, 9, 3, 7]);
+    expect(isMinHeap(heapValues(step))).toBe(true);
+  });
+
+  it("puts the minimum at the root", () => {
+    const step = lastStep([10, 4, 7, 2, 8, 6]);
+    expect(step.nodes[0]!.value).toBe(2);
+  });
+
+  it("preserves all input values", () => {
+    const input = [5, 2, 8, 1, 9, 3, 7];
+    const step = lastStep(input);
+    expect([...heapValues(step)].sort((a, b) => a - b)).toEqual(
+      [...input].sort((a, b) => a - b)
+    );
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [3, 1, 2];
+    minHeapInsert(input);
+    expect(input).toEqual([3, 1, 2]);
+  });
+
+  it("annotates steps with lineNumber", () => {
+    const viz = minHeapInsert([5, 1]);
+    for (const step of viz.steps) {
+      expect("lineNumber" in step).toBe(true);
+    }
+  });
+});

--- a/__tests__/lib/algorithms/dp/dp.test.ts
+++ b/__tests__/lib/algorithms/dp/dp.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { editDistance } from "@/lib/algorithms/dp/editDistance";
+import { lcs } from "@/lib/algorithms/dp/lcs";
+import type { GridStep } from "@/lib/types";
+
+function lastCell(viz: ReturnType<typeof editDistance>): number {
+  const last = viz.steps[viz.steps.length - 1] as GridStep;
+  return last.cells[last.rows - 1]![last.cols - 1] as number;
+}
+
+describe("editDistance", () => {
+  it("returns metadata", () => {
+    const viz = editDistance("a", "b");
+    expect(viz.key).toBe("editDistance");
+    expect(viz.category).toBe("dp");
+    expect(viz.primitive).toBe("grid-2d");
+    expect(viz.steps.length).toBeGreaterThan(0);
+  });
+
+  it("computes the canonical kitten/sitting distance of 3", () => {
+    expect(lastCell(editDistance("kitten", "sitting"))).toBe(3);
+  });
+
+  it("returns 0 for identical strings", () => {
+    expect(lastCell(editDistance("abc", "abc"))).toBe(0);
+  });
+
+  it("returns the length of the other string when one is empty", () => {
+    expect(lastCell(editDistance("", "hello"))).toBe(5);
+    expect(lastCell(editDistance("hello", ""))).toBe(5);
+  });
+
+  it("counts a single substitution", () => {
+    expect(lastCell(editDistance("cat", "bat"))).toBe(1);
+  });
+
+  it("emits a final step that includes a traceback path", () => {
+    const viz = editDistance("ab", "ba");
+    const last = viz.steps[viz.steps.length - 1] as GridStep;
+    expect(last.path.length).toBeGreaterThan(0);
+  });
+
+  it("annotates steps with lineNumber", () => {
+    const viz = editDistance("a", "b");
+    for (const step of viz.steps) {
+      expect("lineNumber" in step).toBe(true);
+    }
+  });
+});
+
+describe("lcs", () => {
+  it("returns metadata", () => {
+    const viz = lcs("a", "b");
+    expect(viz.key).toBe("lcs");
+    expect(viz.category).toBe("dp");
+    expect(viz.primitive).toBe("grid-2d");
+  });
+
+  it("computes the canonical AGCAT/GAC LCS length of 2", () => {
+    expect(lastCell(lcs("AGCAT", "GAC"))).toBe(2);
+  });
+
+  it("returns the full length when one string is a subsequence of the other", () => {
+    expect(lastCell(lcs("abc", "aXbYc"))).toBe(3);
+  });
+
+  it("returns 0 for disjoint strings", () => {
+    expect(lastCell(lcs("abc", "xyz"))).toBe(0);
+  });
+
+  it("returns the string length for identical strings", () => {
+    expect(lastCell(lcs("hello", "hello"))).toBe(5);
+  });
+
+  it("handles empty inputs", () => {
+    expect(lastCell(lcs("", "anything"))).toBe(0);
+    expect(lastCell(lcs("anything", ""))).toBe(0);
+  });
+
+  it("annotates steps with lineNumber", () => {
+    const viz = lcs("a", "b");
+    for (const step of viz.steps) {
+      expect("lineNumber" in step).toBe(true);
+    }
+  });
+});

--- a/app/datastructure/[algorithm]/page.tsx
+++ b/app/datastructure/[algorithm]/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Suspense, useEffect, useRef } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import PageLayout from "@/components/layout/PageLayout";
+import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
+import { useAlgorithm } from "@/context/AlgorithmContext";
+import { getDataStructureAlgorithm } from "@/lib/algorithms";
+import { availableAlgorithms } from "@/lib/algorithms/metadata";
+import { decodeUrlParams, encodeUrlParams } from "@/lib/urlState";
+
+function DataStructurePageInner() {
+  const params = useParams();
+  const algorithmKey = params.algorithm as string;
+  const { dispatch, state } = useAlgorithm();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initializedFromUrl = useRef(false);
+
+  const algorithmInfo = availableAlgorithms[algorithmKey];
+
+  useEffect(() => {
+    if (initializedFromUrl.current) return;
+    initializedFromUrl.current = true;
+    const decoded = decodeUrlParams(searchParams);
+    if (decoded.data) dispatch({ type: "SET_DATA", payload: decoded.data });
+    if (decoded.speed) dispatch({ type: "SET_SPEED", payload: decoded.speed });
+  }, [searchParams, dispatch]);
+
+  useEffect(() => {
+    if (!algorithmKey) return;
+    dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
+    if (!state.visualizationData || algorithmKey !== state.algorithm) {
+      const fn = getDataStructureAlgorithm(algorithmKey);
+      if (fn) {
+        const viz = fn(state.data);
+        dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+      }
+    }
+  }, [
+    algorithmKey,
+    dispatch,
+    state.algorithm,
+    state.data,
+    state.visualizationData,
+  ]);
+
+  useEffect(() => {
+    const urlParams = encodeUrlParams({ data: state.data, speed: state.speed });
+    router.replace(`?${urlParams.toString()}`, { scroll: false });
+  }, [state.data, state.speed, router]);
+
+  if (!algorithmInfo) {
+    return (
+      <PageLayout title="Algorithm Not Found">
+        <div className="py-12 text-center">
+          <h2 className="heading-lg text-red-600">Algorithm Not Found</h2>
+          <p className="mt-4 text-gray-600">
+            The algorithm you are looking for does not exist or is not
+            available.
+          </p>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout
+      title={algorithmInfo.name}
+      subtitle={algorithmInfo.subtitle}
+      {...(state.visualizationData !== null
+        ? { algorithmData: state.visualizationData }
+        : {})}
+    >
+      <AlgorithmVisualizer />
+    </PageLayout>
+  );
+}
+
+export default function DataStructureAlgorithmPage() {
+  return (
+    <Suspense>
+      <DataStructurePageInner />
+    </Suspense>
+  );
+}

--- a/app/datastructure/page.tsx
+++ b/app/datastructure/page.tsx
@@ -12,7 +12,7 @@ export default function DataStructureAlgorithms() {
       title="Data Structures"
       subtitle="Visualize how core data structures are built — see the comparisons, links, and rebalancing decisions one step at a time."
     >
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {dsAlgorithms.map((algorithm) => (
           <AlgorithmCard key={algorithm[0]} algorithm={algorithm[1]} />
         ))}

--- a/app/datastructure/page.tsx
+++ b/app/datastructure/page.tsx
@@ -1,0 +1,22 @@
+import PageLayout from "@/components/layout/PageLayout";
+import AlgorithmCard from "@/components/AlgorithmCard";
+import { availableAlgorithms } from "@/lib/algorithms/metadata";
+
+export default function DataStructureAlgorithms() {
+  const dsAlgorithms = Object.entries(availableAlgorithms).filter(
+    ([, algo]) => algo.category === "datastructure"
+  );
+
+  return (
+    <PageLayout
+      title="Data Structures"
+      subtitle="Visualize how core data structures are built — see the comparisons, links, and rebalancing decisions one step at a time."
+    >
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {dsAlgorithms.map((algorithm) => (
+          <AlgorithmCard key={algorithm[0]} algorithm={algorithm[1]} />
+        ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/app/dp/[algorithm]/page.tsx
+++ b/app/dp/[algorithm]/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import PageLayout from "@/components/layout/PageLayout";
+import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
+import StringPairInputPanel from "@/components/visualizer/StringPairInputPanel";
+import { useAlgorithm } from "@/context/AlgorithmContext";
+import { getDpAlgorithm } from "@/lib/algorithms";
+import { availableAlgorithms } from "@/lib/algorithms/metadata";
+
+const DEFAULT_PAIRS: Array<[string, string]> = [
+  ["kitten", "sitting"],
+  ["intention", "execution"],
+  ["GACGTAC", "GTGTACG"],
+  ["AGCAT", "GAC"],
+  ["sunday", "saturday"],
+];
+
+function randomPair(): [string, string] {
+  const idx = Math.floor(Math.random() * DEFAULT_PAIRS.length);
+  return DEFAULT_PAIRS[idx]!;
+}
+
+function readStringParam(
+  params: URLSearchParams,
+  key: string,
+  fallback: string
+): string {
+  const raw = params.get(key);
+  if (raw === null) return fallback;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0 || trimmed.length > 12) return fallback;
+  return trimmed;
+}
+
+function DpPageInner() {
+  const params = useParams();
+  const algorithmKey = params.algorithm as string;
+  const { dispatch } = useAlgorithm();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initializedFromUrl = useRef(false);
+
+  const algorithmInfo = availableAlgorithms[algorithmKey];
+
+  const [stringA, setStringA] = useState("kitten");
+  const [stringB, setStringB] = useState("sitting");
+
+  useEffect(() => {
+    if (initializedFromUrl.current) return;
+    initializedFromUrl.current = true;
+    const a = readStringParam(searchParams, "a", "kitten");
+    const b = readStringParam(searchParams, "b", "sitting");
+    setStringA(a);
+    setStringB(b);
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!algorithmKey) return;
+    dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
+    const fn = getDpAlgorithm(algorithmKey);
+    if (!fn) return;
+    try {
+      const viz = fn(stringA, stringB);
+      dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+    } catch (error) {
+      console.error("Error generating visualization:", error);
+    }
+  }, [algorithmKey, stringA, stringB, dispatch]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    params.set("a", stringA);
+    params.set("b", stringB);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }, [stringA, stringB, router]);
+
+  if (!algorithmInfo) {
+    return (
+      <PageLayout title="Algorithm Not Found">
+        <div className="py-12 text-center">
+          <h2 className="heading-lg text-red-600">Algorithm Not Found</h2>
+          <p className="mt-4 text-gray-600">
+            The algorithm you are looking for does not exist or is not
+            available.
+          </p>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  const handleSet = (a: string, b: string) => {
+    setStringA(a);
+    setStringB(b);
+  };
+
+  const handleRandomize = () => {
+    const [a, b] = randomPair();
+    setStringA(a);
+    setStringB(b);
+  };
+
+  return (
+    <PageLayout title={algorithmInfo.name} subtitle={algorithmInfo.subtitle}>
+      <div className="mb-6">
+        <StringPairInputPanel
+          initialA={stringA}
+          initialB={stringB}
+          onSet={handleSet}
+          onRandomize={handleRandomize}
+        />
+      </div>
+      <AlgorithmVisualizer />
+    </PageLayout>
+  );
+}
+
+export default function DpAlgorithmPage() {
+  return (
+    <Suspense>
+      <DpPageInner />
+    </Suspense>
+  );
+}

--- a/app/dp/page.tsx
+++ b/app/dp/page.tsx
@@ -1,0 +1,22 @@
+import PageLayout from "@/components/layout/PageLayout";
+import AlgorithmCard from "@/components/AlgorithmCard";
+import { availableAlgorithms } from "@/lib/algorithms/metadata";
+
+export default function DpAlgorithms() {
+  const dpAlgorithms = Object.entries(availableAlgorithms).filter(
+    ([, algo]) => algo.category === "dp"
+  );
+
+  return (
+    <PageLayout
+      title="Dynamic Programming"
+      subtitle="Watch DP tables fill cell-by-cell — see how each subproblem builds on its dependencies and how the final answer is reconstructed via traceback."
+    >
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+        {dpAlgorithms.map((algorithm) => (
+          <AlgorithmCard key={algorithm[0]} algorithm={algorithm[1]} />
+        ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/app/dp/page.tsx
+++ b/app/dp/page.tsx
@@ -12,7 +12,7 @@ export default function DpAlgorithms() {
       title="Dynamic Programming"
       subtitle="Watch DP tables fill cell-by-cell — see how each subproblem builds on its dependencies and how the final answer is reconstructed via traceback."
     >
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
         {dpAlgorithms.map((algorithm) => (
           <AlgorithmCard key={algorithm[0]} algorithm={algorithm[1]} />
         ))}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,22 +2,37 @@ import Link from "next/link";
 import PageLayout from "@/components/layout/PageLayout";
 import AlgorithmCard from "@/components/AlgorithmCard";
 import { availableAlgorithms } from "@/lib/algorithms/metadata";
-import type { AlgorithmInfo } from "@/lib/types";
+import type { AlgorithmCategory, AlgorithmInfo } from "@/lib/types";
+
+const CATEGORY_LABELS: Record<AlgorithmCategory, string> = {
+  sorting: "Sorting Algorithms",
+  searching: "Searching Algorithms",
+  graph: "Graph Algorithms",
+  datastructure: "Data Structures",
+  dp: "Dynamic Programming",
+};
+
+const CATEGORY_ORDER: AlgorithmCategory[] = [
+  "sorting",
+  "searching",
+  "graph",
+  "datastructure",
+  "dp",
+];
 
 export default function Home() {
-  // Group algorithms by category
-  const algorithmsByCategory = Object.entries(
-    Object.entries(availableAlgorithms).reduce(
-      (acc, [, algorithm]) => {
-        const { category } = algorithm;
-        if (!acc[category]) {
-          acc[category] = [];
-        }
-        acc[category].push(algorithm);
-        return acc;
-      },
-      {} as Record<string, AlgorithmInfo[]>
-    )
+  const grouped = Object.values(availableAlgorithms).reduce(
+    (acc, algorithm) => {
+      const list = acc[algorithm.category] ?? [];
+      list.push(algorithm);
+      acc[algorithm.category] = list;
+      return acc;
+    },
+    {} as Partial<Record<AlgorithmCategory, AlgorithmInfo[]>>
+  );
+
+  const sections = CATEGORY_ORDER.filter(
+    (category) => (grouped[category]?.length ?? 0) > 0
   );
 
   return (
@@ -25,19 +40,19 @@ export default function Home() {
       title="Algorithm Visualizer"
       subtitle="Interactive visualizations to help you understand how algorithms work step-by-step."
     >
-      {algorithmsByCategory.map((category) => (
-        <section key={category[0]} className="mb-12">
+      {sections.map((category) => (
+        <section key={category} className="mb-12">
           <div className="mb-6 flex items-center justify-between">
-            <h2 className="heading-lg text-white capitalize">
-              {category[0]} Algorithms
+            <h2 className="heading-lg text-white">
+              {CATEGORY_LABELS[category]}
             </h2>
-            <Link href={`/${category[0]}`} className="btn btn-primary text-sm">
+            <Link href={`/${category}`} className="btn btn-primary text-sm">
               View All
             </Link>
           </div>
 
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-            {category[1].slice(0, 3).map((algorithm) => (
+            {(grouped[category] ?? []).slice(0, 3).map((algorithm) => (
               <AlgorithmCard key={algorithm.key} algorithm={algorithm} />
             ))}
           </div>

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -44,6 +44,18 @@ function buildStaticPages(baseUrl: string): MetadataRoute.Sitemap {
       priority: 0.9,
     },
     {
+      url: `${baseUrl}/datastructure`,
+      lastModified: new Date(),
+      changeFrequency: weekly,
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/dp`,
+      lastModified: new Date(),
+      changeFrequency: weekly,
+      priority: 0.9,
+    },
+    {
       url: `${baseUrl}/glossary`,
       lastModified: new Date(),
       changeFrequency: monthly,

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -60,6 +60,8 @@ const navLinks = [
   { href: "/sorting", label: "Sorting" },
   { href: "/searching", label: "Searching" },
   { href: "/graph", label: "Graph" },
+  { href: "/datastructure", label: "Data Structures" },
+  { href: "/dp", label: "DP" },
   { href: "/difficulty", label: "Difficulty" },
   { href: "/glossary", label: "Glossary" },
 ];

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -111,10 +111,10 @@ export default function Navbar() {
 
   return (
     <header className="bg-white shadow">
-      <div className="max-w-7xl mx-auto py-6 px-4 sm:px-6 flex items-center justify-between lg:px-8">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-6 sm:px-6 lg:px-8">
         <Link href="/" className="flex items-center space-x-2">
           <svg
-            className="w-8 h-8 text-blue-600"
+            className="h-8 w-8 text-blue-600"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -131,7 +131,7 @@ export default function Navbar() {
           </span>
         </Link>
 
-        <nav className="hidden md:flex space-x-8">
+        <nav className="hidden space-x-8 md:flex">
           {navLinks.map((link) => (
             <NavLink
               key={link.label}
@@ -155,7 +155,7 @@ export default function Navbar() {
             href="https://github.com/Scc33/algorithm-visualizer"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-gray-500 hover:text-gray-700 mr-4"
+            className="mr-4 text-gray-500 hover:text-gray-700"
           >
             <span className="sr-only">GitHub</span>
             <GitHubIcon />
@@ -163,7 +163,7 @@ export default function Navbar() {
           <button
             id="mobile-menu-button"
             type="button"
-            className="inline-flex items-center justify-center p-2 rounded-md text-gray-500 hover:text-gray-900 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-blue-500 cursor-pointer"
+            className="inline-flex cursor-pointer items-center justify-center rounded-md p-2 text-gray-500 hover:bg-gray-100 hover:text-gray-900 focus:ring-2 focus:ring-blue-500 focus:outline-none focus:ring-inset"
             aria-controls="mobile-menu"
             aria-expanded={isMenuOpen}
             onClick={() => setIsMenuOpen(!isMenuOpen)}
@@ -181,12 +181,12 @@ export default function Navbar() {
         className={`${isMenuOpen ? "block" : "hidden"} md:hidden`}
         aria-labelledby="mobile-menu-button"
       >
-        <div className="px-2 pt-2 pb-3 space-y-1 sm:px-3 bg-white shadow-lg border-t">
+        <div className="space-y-1 border-t bg-white px-2 pt-2 pb-3 shadow-lg sm:px-3">
           {navLinks.map((link) => (
             <Link
               key={link.href}
               href={link.href}
-              className={`block px-3 py-2 rounded-md text-base font-medium ${
+              className={`block rounded-md px-3 py-2 text-base font-medium ${
                 isActive(link.href)
                   ? "bg-blue-50 text-blue-700"
                   : "text-gray-700 hover:bg-gray-50"
@@ -214,7 +214,7 @@ function NavLink({
     <Link
       href={href}
       className={`py-2 text-sm font-medium transition-colors hover:text-blue-600 ${
-        active ? "text-blue-600 border-b-2 border-blue-600" : "text-gray-700"
+        active ? "border-b-2 border-blue-600 text-blue-600" : "text-gray-700"
       }`}
     >
       {children}

--- a/components/primitives/Grid2D.tsx
+++ b/components/primitives/Grid2D.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import type { GridCoord, GridStep } from "@/lib/types";
+
+function coordKey(c: GridCoord): string {
+  return `${c.row}:${c.col}`;
+}
+
+function cellClasses(
+  row: number,
+  col: number,
+  step: GridStep,
+  highlightedSet: Set<string>,
+  pathSet: Set<string>
+): string {
+  const isCurrent =
+    step.current !== null &&
+    step.current.row === row &&
+    step.current.col === col;
+  const key = coordKey({ row, col });
+  if (isCurrent) return "bg-yellow-300 border-yellow-500";
+  if (pathSet.has(key)) return "bg-emerald-200 border-emerald-400";
+  if (highlightedSet.has(key)) return "bg-blue-100 border-blue-300";
+  return "bg-white border-gray-200";
+}
+
+interface Grid2DProps {
+  step: GridStep;
+}
+
+export default function Grid2D({ step }: Grid2DProps) {
+  const highlightedSet = new Set(step.highlighted.map(coordKey));
+  const pathSet = new Set(step.path.map(coordKey));
+
+  const hasColLabels = step.colLabels.length > 0;
+  const hasRowLabels = step.rowLabels.length > 0;
+  const cellSize = step.cols > 8 ? "h-9 w-9 text-xs" : "h-11 w-11 text-sm";
+
+  return (
+    <div className="flex w-full flex-col items-center overflow-x-auto bg-white p-6">
+      <table className="border-separate border-spacing-1">
+        {hasColLabels && (
+          <thead>
+            <tr>
+              {hasRowLabels && <th className={cellSize} />}
+              {step.colLabels.map((label, i) => (
+                <th
+                  key={`col-${i}`}
+                  className={`${cellSize} font-mono text-gray-500`}
+                >
+                  {label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+        )}
+        <tbody>
+          {step.cells.map((row, rIdx) => (
+            <tr key={`row-${rIdx}`}>
+              {hasRowLabels && (
+                <th
+                  className={`${cellSize} font-mono text-gray-500`}
+                  scope="row"
+                >
+                  {step.rowLabels[rIdx] ?? ""}
+                </th>
+              )}
+              {row.map((value, cIdx) => (
+                <td
+                  key={`cell-${rIdx}-${cIdx}`}
+                  className={`${cellSize} rounded border text-center font-mono font-medium text-gray-800 transition-colors ${cellClasses(
+                    rIdx,
+                    cIdx,
+                    step,
+                    highlightedSet,
+                    pathSet
+                  )}`}
+                >
+                  {value === null ? "" : value}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {step.message && (
+        <div className="mt-4 w-full rounded-md bg-gray-50 p-3 text-sm text-gray-700">
+          {step.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/primitives/TreeShape.tsx
+++ b/components/primitives/TreeShape.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { BinaryTreeNode, TreeStep } from "@/lib/types";
+
+interface PositionedNode {
+  node: BinaryTreeNode;
+  x: number;
+  y: number;
+}
+
+const NODE_RADIUS = 22;
+const VERTICAL_GAP = 70;
+const HORIZONTAL_PADDING = 40;
+const MIN_HEIGHT = 220;
+const MIN_WIDTH = 360;
+
+function findDepth(nodes: BinaryTreeNode[], rootId: number | null): number {
+  if (rootId === null) return 0;
+  const map = new Map(nodes.map((n) => [n.id, n]));
+  const walk = (id: number | null): number => {
+    if (id === null) return 0;
+    const n = map.get(id);
+    if (!n) return 0;
+    return 1 + Math.max(walk(n.left), walk(n.right));
+  };
+  return walk(rootId);
+}
+
+function layoutTree(
+  nodes: BinaryTreeNode[],
+  rootId: number | null,
+  width: number
+): PositionedNode[] {
+  if (rootId === null || nodes.length === 0) return [];
+  const map = new Map(nodes.map((n) => [n.id, n]));
+  const out: PositionedNode[] = [];
+
+  const place = (
+    id: number | null,
+    depth: number,
+    minX: number,
+    maxX: number
+  ) => {
+    if (id === null) return;
+    const n = map.get(id);
+    if (!n) return;
+    const x = (minX + maxX) / 2;
+    const y = HORIZONTAL_PADDING + depth * VERTICAL_GAP;
+    out.push({ node: n, x, y });
+    place(n.left, depth + 1, minX, x);
+    place(n.right, depth + 1, x, maxX);
+  };
+
+  place(rootId, 0, HORIZONTAL_PADDING, width - HORIZONTAL_PADDING);
+  return out;
+}
+
+function nodeFill(id: number, step: TreeStep): string {
+  if (step.inserted === id) return "#34D399";
+  if (step.current === id) return "#FCD34D";
+  if (step.compared.includes(id)) return "#FCA5A5";
+  if (step.highlighted.includes(id)) return "#93C5FD";
+  return "#E5E7EB";
+}
+
+interface TreeShapeProps {
+  step: TreeStep;
+}
+
+export default function TreeShape({ step }: TreeShapeProps) {
+  const [size, setSize] = useState({ width: MIN_WIDTH, height: MIN_HEIGHT });
+
+  useEffect(() => {
+    const update = () => {
+      const width = Math.max(MIN_WIDTH, Math.min(640, window.innerWidth - 60));
+      setSize({ width, height: MIN_HEIGHT });
+    };
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, []);
+
+  const depth = findDepth(step.nodes, step.rootId);
+  const height = Math.max(
+    MIN_HEIGHT,
+    HORIZONTAL_PADDING * 2 + depth * VERTICAL_GAP
+  );
+  const positions = layoutTree(step.nodes, step.rootId, size.width);
+  const positionMap = new Map(positions.map((p) => [p.node.id, p]));
+
+  return (
+    <div className="flex w-full flex-col items-center bg-white p-6">
+      <div
+        className="relative rounded-lg border bg-gray-50"
+        style={{ width: size.width, height }}
+      >
+        <svg width={size.width} height={height}>
+          {positions.map(({ node, x, y }) => {
+            const left = node.left !== null ? positionMap.get(node.left) : null;
+            const right =
+              node.right !== null ? positionMap.get(node.right) : null;
+            return (
+              <g key={`edges-${node.id}`}>
+                {left && (
+                  <line
+                    x1={x}
+                    y1={y}
+                    x2={left.x}
+                    y2={left.y}
+                    stroke="#9CA3AF"
+                    strokeWidth={2}
+                  />
+                )}
+                {right && (
+                  <line
+                    x1={x}
+                    y1={y}
+                    x2={right.x}
+                    y2={right.y}
+                    stroke="#9CA3AF"
+                    strokeWidth={2}
+                  />
+                )}
+              </g>
+            );
+          })}
+          {positions.map(({ node, x, y }) => (
+            <g key={`node-${node.id}`}>
+              <circle
+                cx={x}
+                cy={y}
+                r={NODE_RADIUS}
+                fill={nodeFill(node.id, step)}
+                stroke="#1F2937"
+                strokeWidth={1.5}
+              />
+              <text
+                x={x}
+                y={y + 4}
+                textAnchor="middle"
+                fontSize={13}
+                fontWeight={600}
+                fill="#111827"
+              >
+                {node.value}
+              </text>
+            </g>
+          ))}
+          {positions.length === 0 && (
+            <text
+              x={size.width / 2}
+              y={height / 2}
+              textAnchor="middle"
+              fontSize={14}
+              fill="#6B7280"
+            >
+              (empty tree)
+            </text>
+          )}
+        </svg>
+      </div>
+      {step.message && (
+        <div className="mt-4 w-full rounded-md bg-gray-50 p-3 text-sm text-gray-700">
+          {step.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/primitives/index.ts
+++ b/components/primitives/index.ts
@@ -4,10 +4,14 @@ import type { AlgorithmVisualization } from "@/lib/types";
 import ArrayBars from "./ArrayBars";
 import ArrayCells from "./ArrayCells";
 import Graph2D from "./Graph2D";
+import TreeShape from "./TreeShape";
+import Grid2D from "./Grid2D";
 
 export { default as ArrayBars } from "./ArrayBars";
 export { default as ArrayCells } from "./ArrayCells";
 export { default as Graph2D } from "./Graph2D";
+export { default as TreeShape } from "./TreeShape";
+export { default as Grid2D } from "./Grid2D";
 export { default as CodeView } from "./CodeView";
 
 /**
@@ -33,6 +37,14 @@ export function renderPrimitive(
     case "graph-2d": {
       const step = viz.steps[currentStep]!;
       return createElement(Graph2D, { step });
+    }
+    case "tree-shape": {
+      const step = viz.steps[currentStep]!;
+      return createElement(TreeShape, { step });
+    }
+    case "grid-2d": {
+      const step = viz.steps[currentStep]!;
+      return createElement(Grid2D, { step });
     }
   }
 }

--- a/components/visualizer/AlgorithmVisualizer.tsx
+++ b/components/visualizer/AlgorithmVisualizer.tsx
@@ -7,9 +7,11 @@ import ArrayInputPanel from "./ArrayInputPanel";
 import { CodeView, renderPrimitive } from "@/components/primitives";
 import { useAlgorithm } from "@/context/AlgorithmContext";
 import {
+  getDataStructureAlgorithm,
   getGraphAlgorithm,
   getSearchAlgorithm,
   getSortingAlgorithm,
+  isDataStructureAlgorithm,
   isGraphAlgorithm,
 } from "@/lib/algorithms";
 import { defaultGraphFor } from "@/lib/algorithms/graph/sampleGraphs";
@@ -67,6 +69,32 @@ function regenerateSort(
   }
 }
 
+function regenerateDataStructure(
+  algorithm: string,
+  data: number[]
+): AlgorithmVisualization | null {
+  if (!isDataStructureAlgorithm(algorithm)) return null;
+  const fn = getDataStructureAlgorithm(algorithm);
+  if (!fn) return null;
+  try {
+    return fn(data);
+  } catch (error) {
+    console.error("Error generating visualization:", error);
+    return null;
+  }
+}
+
+function regenerateForArrayCategory(
+  category: string,
+  algorithm: string,
+  data: number[],
+  target: number
+): AlgorithmVisualization | null {
+  if (category === "searching") return regenerateSearch(algorithm, data, target);
+  if (category === "datastructure") return regenerateDataStructure(algorithm, data);
+  return regenerateSort(algorithm, data);
+}
+
 export default function AlgorithmVisualizer() {
   const { state, dispatch } = useAlgorithm();
   const { currentStep, algorithm, data, visualizationData, target } = state;
@@ -86,7 +114,8 @@ export default function AlgorithmVisualizer() {
       return;
     }
 
-    const newData = generateRandomArray(5, 95, 15);
+    const length = category === "datastructure" ? 7 : 15;
+    const newData = generateRandomArray(5, 95, length);
     dispatch({ type: "SET_DATA", payload: newData });
 
     if (category === "searching") {
@@ -94,10 +123,13 @@ export default function AlgorithmVisualizer() {
       dispatch({ type: "SET_TARGET", payload: newTarget });
       const viz = regenerateSearch(algorithm, newData, newTarget);
       if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
-    } else {
-      const viz = regenerateSort(algorithm, newData);
-      if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+      return;
     }
+    const viz =
+      category === "datastructure"
+        ? regenerateDataStructure(algorithm, newData)
+        : regenerateSort(algorithm, newData);
+    if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
   };
 
   const handleSetArray = (newData: number[]) => {
@@ -106,10 +138,12 @@ export default function AlgorithmVisualizer() {
     if (target === undefined) {
       dispatch({ type: "SET_TARGET", payload: currentTarget });
     }
-    const viz =
-      category === "searching"
-        ? regenerateSearch(algorithm, newData, currentTarget)
-        : regenerateSort(algorithm, newData);
+    const viz = regenerateForArrayCategory(
+      category,
+      algorithm,
+      newData,
+      currentTarget
+    );
     if (viz) dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
   };
 
@@ -165,6 +199,8 @@ export default function AlgorithmVisualizer() {
           <ColorLegend
             isSearchAlgorithm={category === "searching"}
             isGraphAlgorithm={category === "graph"}
+            isTreeAlgorithm={category === "datastructure"}
+            isGridAlgorithm={category === "dp"}
           />
         </div>
 

--- a/components/visualizer/AlgorithmVisualizer.tsx
+++ b/components/visualizer/AlgorithmVisualizer.tsx
@@ -90,8 +90,10 @@ function regenerateForArrayCategory(
   data: number[],
   target: number
 ): AlgorithmVisualization | null {
-  if (category === "searching") return regenerateSearch(algorithm, data, target);
-  if (category === "datastructure") return regenerateDataStructure(algorithm, data);
+  if (category === "searching")
+    return regenerateSearch(algorithm, data, target);
+  if (category === "datastructure")
+    return regenerateDataStructure(algorithm, data);
   return regenerateSort(algorithm, data);
 }
 
@@ -182,14 +184,16 @@ export default function AlgorithmVisualizer() {
             {renderPrimitive(visualizationData, currentStep)}
           </div>
 
-          <ArrayInputPanel
-            category={category}
-            numVertices={numVertices}
-            onSetArray={handleSetArray}
-            onSetTarget={handleSetTarget}
-            onSetStart={handleSetStart}
-            onRandomize={handleRandomize}
-          />
+          {category !== "dp" && (
+            <ArrayInputPanel
+              category={category}
+              numVertices={numVertices}
+              onSetArray={handleSetArray}
+              onSetTarget={handleSetTarget}
+              onSetStart={handleSetStart}
+              onRandomize={handleRandomize}
+            />
+          )}
 
           <VisualizerControls
             currentStep={currentStep}

--- a/components/visualizer/ColorLegend.tsx
+++ b/components/visualizer/ColorLegend.tsx
@@ -59,13 +59,13 @@ export default function ColorLegend(props: ColorLegendProps) {
 
   return (
     <div className="card p-4">
-      <h3 className="text-sm font-medium text-gray-700 mb-3">Color Legend</h3>
+      <h3 className="mb-3 text-sm font-medium text-gray-700">Color Legend</h3>
 
       <div className="flex flex-wrap gap-4">
         {legendItems.map((item) => (
           <div key={item.label} className="flex items-center">
             <div
-              className={`w-4 h-4 rounded mr-2 ${item.color}`}
+              className={`mr-2 h-4 w-4 rounded ${item.color}`}
               aria-hidden="true"
             ></div>
             <span className="text-sm text-gray-700">{item.label}</span>

--- a/components/visualizer/ColorLegend.tsx
+++ b/components/visualizer/ColorLegend.tsx
@@ -1,40 +1,61 @@
 interface ColorLegendProps {
   isSearchAlgorithm?: boolean;
   isGraphAlgorithm?: boolean;
+  isTreeAlgorithm?: boolean;
+  isGridAlgorithm?: boolean;
 }
 
-export default function ColorLegend({
-  isSearchAlgorithm = false,
-  isGraphAlgorithm = false,
-}: ColorLegendProps) {
-  const sortingLegendItems = [
-    { color: "bg-blue-400", label: "Unsorted" },
-    { color: "bg-yellow-400", label: "Comparing" },
-    { color: "bg-red-400", label: "Swapping" },
-    { color: "bg-green-400", label: "Sorted" },
-  ];
+interface LegendItem {
+  color: string;
+  label: string;
+}
 
-  const searchLegendItems = [
-    { color: "bg-blue-400", label: "Unvisited" },
-    { color: "bg-yellow-400", label: "Current" },
-    { color: "bg-gray-400", label: "Visited" },
-    { color: "bg-green-500", label: "Found" },
-  ];
+const sortingItems: LegendItem[] = [
+  { color: "bg-blue-400", label: "Unsorted" },
+  { color: "bg-yellow-400", label: "Comparing" },
+  { color: "bg-red-400", label: "Swapping" },
+  { color: "bg-green-400", label: "Sorted" },
+];
 
-  const graphLegendItems = [
-    { color: "bg-blue-300", label: "Unvisited Vertex" },
-    { color: "bg-yellow-300", label: "Current Vertex" },
-    { color: "bg-green-300", label: "Visited Vertex" },
-    { color: "bg-red-400", label: "Path Edge" },
-  ];
+const searchItems: LegendItem[] = [
+  { color: "bg-blue-400", label: "Unvisited" },
+  { color: "bg-yellow-400", label: "Current" },
+  { color: "bg-gray-400", label: "Visited" },
+  { color: "bg-green-500", label: "Found" },
+];
 
-  let legendItems = sortingLegendItems;
+const graphItems: LegendItem[] = [
+  { color: "bg-blue-300", label: "Unvisited Vertex" },
+  { color: "bg-yellow-300", label: "Current Vertex" },
+  { color: "bg-green-300", label: "Visited Vertex" },
+  { color: "bg-red-400", label: "Path Edge" },
+];
 
-  if (isSearchAlgorithm) {
-    legendItems = searchLegendItems;
-  } else if (isGraphAlgorithm) {
-    legendItems = graphLegendItems;
-  }
+const treeItems: LegendItem[] = [
+  { color: "bg-gray-200", label: "Existing Node" },
+  { color: "bg-blue-300", label: "Path / Visited" },
+  { color: "bg-yellow-300", label: "Current Node" },
+  { color: "bg-red-300", label: "Compared" },
+  { color: "bg-emerald-400", label: "Just Inserted" },
+];
+
+const gridItems: LegendItem[] = [
+  { color: "bg-white border border-gray-300", label: "Empty / Filled" },
+  { color: "bg-blue-100", label: "Dependency" },
+  { color: "bg-yellow-300", label: "Current Cell" },
+  { color: "bg-emerald-200", label: "Solution Path" },
+];
+
+function pickItems(props: ColorLegendProps): LegendItem[] {
+  if (props.isSearchAlgorithm) return searchItems;
+  if (props.isGraphAlgorithm) return graphItems;
+  if (props.isTreeAlgorithm) return treeItems;
+  if (props.isGridAlgorithm) return gridItems;
+  return sortingItems;
+}
+
+export default function ColorLegend(props: ColorLegendProps) {
+  const legendItems = pickItems(props);
 
   return (
     <div className="card p-4">

--- a/components/visualizer/StringPairInputPanel.tsx
+++ b/components/visualizer/StringPairInputPanel.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const MIN_LEN = 1;
+const MAX_LEN = 12;
+
+function validate(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length < MIN_LEN) return `Enter at least ${MIN_LEN} character.`;
+  if (trimmed.length > MAX_LEN) return `Enter at most ${MAX_LEN} characters.`;
+  return null;
+}
+
+interface StringPairInputPanelProps {
+  initialA: string;
+  initialB: string;
+  onSet: (a: string, b: string) => void;
+  onRandomize: () => void;
+}
+
+function FieldError({ message }: { message: string | null }) {
+  if (!message) return null;
+  return (
+    <p className="text-sm text-red-600" role="alert">
+      {message}
+    </p>
+  );
+}
+
+export default function StringPairInputPanel({
+  initialA,
+  initialB,
+  onSet,
+  onRandomize,
+}: StringPairInputPanelProps) {
+  const [aDraft, setADraft] = useState(initialA);
+  const [bDraft, setBDraft] = useState(initialB);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setADraft(initialA);
+    setBDraft(initialB);
+    setError(null);
+  }, [initialA, initialB]);
+
+  const handleApply = () => {
+    const aError = validate(aDraft);
+    const bError = validate(bDraft);
+    if (aError || bError) {
+      setError(aError ?? bError);
+      return;
+    }
+    setError(null);
+    onSet(aDraft.trim(), bDraft.trim());
+  };
+
+  return (
+    <div className="card space-y-4 p-6">
+      <h3 className="text-sm font-semibold tracking-wide text-gray-700 uppercase">
+        Input Strings
+      </h3>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+          String A (1–12 chars)
+          <input
+            type="text"
+            value={aDraft}
+            onChange={(e) => setADraft(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleApply()}
+            className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            aria-label="String A"
+            maxLength={MAX_LEN}
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm font-medium text-gray-700">
+          String B (1–12 chars)
+          <input
+            type="text"
+            value={bDraft}
+            onChange={(e) => setBDraft(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleApply()}
+            className="rounded border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none"
+            aria-label="String B"
+            maxLength={MAX_LEN}
+          />
+        </label>
+      </div>
+      <div className="flex gap-2">
+        <button onClick={handleApply} className="btn btn-primary">
+          Set
+        </button>
+        <button onClick={onRandomize} className="btn btn-secondary">
+          Randomize
+        </button>
+      </div>
+      <FieldError message={error} />
+    </div>
+  );
+}

--- a/lib/algorithms/datastructure/bst.ts
+++ b/lib/algorithms/datastructure/bst.ts
@@ -1,0 +1,188 @@
+import type {
+  AlgorithmVisualization,
+  BinaryTreeNode,
+  TreeStep,
+} from "../../types";
+import { createVisualization } from "../utils";
+
+const PSEUDO = [
+  "procedure bstInsert(root, value)",
+  "  if root is null then",
+  "    return new Node(value)",
+  "  if value < root.value then",
+  "    root.left := bstInsert(root.left, value)",
+  "  else if value > root.value then",
+  "    root.right := bstInsert(root.right, value)",
+  "  return root",
+  "end procedure",
+];
+
+interface BstState {
+  nodes: BinaryTreeNode[];
+  rootId: number | null;
+  nextId: number;
+}
+
+function snapshot(
+  state: BstState,
+  partial: Omit<TreeStep, "nodes" | "rootId">
+): TreeStep {
+  return {
+    nodes: state.nodes.map((n) => ({ ...n })),
+    rootId: state.rootId,
+    ...partial,
+  };
+}
+
+function newNode(state: BstState, value: number): BinaryTreeNode {
+  const node: BinaryTreeNode = {
+    id: state.nextId++,
+    value,
+    left: null,
+    right: null,
+  };
+  state.nodes.push(node);
+  return node;
+}
+
+function findById(state: BstState, id: number): BinaryTreeNode | undefined {
+  return state.nodes.find((n) => n.id === id);
+}
+
+interface AttachArgs {
+  state: BstState;
+  parent: BinaryTreeNode;
+  side: "left" | "right";
+  value: number;
+  path: number[];
+  steps: TreeStep[];
+}
+
+function attachChild(args: AttachArgs): void {
+  const { state, parent, side, value, path, steps } = args;
+  const child = newNode(state, value);
+  parent[side] = child.id;
+  steps.push(
+    snapshot(state, {
+      current: parent.id,
+      highlighted: [...path, child.id],
+      compared: [],
+      inserted: child.id,
+      message: `Inserting ${value} as ${side} child of ${parent.value}.`,
+      lineNumber: side === "left" ? 4 : 6,
+    })
+  );
+}
+
+function insertAtRoot(state: BstState, value: number, steps: TreeStep[]): void {
+  const root = newNode(state, value);
+  state.rootId = root.id;
+  steps.push(
+    snapshot(state, {
+      current: null,
+      highlighted: [root.id],
+      compared: [],
+      inserted: root.id,
+      message: `Inserting ${value} as the root.`,
+      lineNumber: 2,
+    })
+  );
+}
+
+function descend(
+  state: BstState,
+  cursor: BinaryTreeNode,
+  value: number,
+  path: number[],
+  steps: TreeStep[]
+): { nextId: number | null; done: boolean } {
+  if (value < cursor.value) {
+    if (cursor.left === null) {
+      attachChild({ state, parent: cursor, side: "left", value, path, steps });
+      return { nextId: null, done: true };
+    }
+    return { nextId: cursor.left, done: false };
+  }
+  if (value > cursor.value) {
+    if (cursor.right === null) {
+      attachChild({ state, parent: cursor, side: "right", value, path, steps });
+      return { nextId: null, done: true };
+    }
+    return { nextId: cursor.right, done: false };
+  }
+  steps.push(
+    snapshot(state, {
+      current: cursor.id,
+      highlighted: [...path],
+      compared: [cursor.id],
+      inserted: null,
+      message: `Value ${value} already in tree; skipping.`,
+      lineNumber: 7,
+    })
+  );
+  return { nextId: null, done: true };
+}
+
+function insertOne(state: BstState, value: number, steps: TreeStep[]): void {
+  if (state.rootId === null) {
+    insertAtRoot(state, value, steps);
+    return;
+  }
+  const path: number[] = [];
+  let cursorId: number | null = state.rootId;
+  while (cursorId !== null) {
+    const cursor = findById(state, cursorId)!;
+    path.push(cursor.id);
+    steps.push(
+      snapshot(state, {
+        current: cursor.id,
+        highlighted: [...path],
+        compared: [cursor.id],
+        inserted: null,
+        message: `Comparing ${value} with ${cursor.value}.`,
+        lineNumber: value < cursor.value ? 3 : 5,
+      })
+    );
+    const { nextId, done } = descend(state, cursor, value, path, steps);
+    if (done) return;
+    cursorId = nextId;
+  }
+}
+
+export function bstInsert(values: number[]): AlgorithmVisualization {
+  const state: BstState = { nodes: [], rootId: null, nextId: 0 };
+  const steps: TreeStep[] = [];
+
+  steps.push({
+    nodes: [],
+    rootId: null,
+    current: null,
+    highlighted: [],
+    compared: [],
+    inserted: null,
+    message: "Starting with an empty BST.",
+    lineNumber: 0,
+  });
+
+  for (const value of values) {
+    insertOne(state, value, steps);
+  }
+
+  steps.push(
+    snapshot(state, {
+      current: null,
+      highlighted: [],
+      compared: [],
+      inserted: null,
+      message: `Built BST with ${state.nodes.length} node(s).`,
+      lineNumber: 7,
+    })
+  );
+
+  return createVisualization("bstInsert", "tree-shape", steps, {
+    timeComplexity: "O(n log n) average / O(n²) worst",
+    spaceComplexity: "O(n)",
+    reference: "https://en.wikipedia.org/wiki/Binary_search_tree",
+    pseudoCode: PSEUDO,
+  });
+}

--- a/lib/algorithms/datastructure/heap.ts
+++ b/lib/algorithms/datastructure/heap.ts
@@ -1,0 +1,127 @@
+import type {
+  AlgorithmVisualization,
+  BinaryTreeNode,
+  TreeStep,
+} from "../../types";
+import { createVisualization } from "../utils";
+
+const PSEUDO = [
+  "procedure heapInsert(heap, value)",
+  "  heap.append(value)",
+  "  i := length(heap) - 1",
+  "  while i > 0 do",
+  "    parent := (i - 1) / 2",
+  "    if heap[i] >= heap[parent] then",
+  "      break",
+  "    swap heap[i] and heap[parent]",
+  "    i := parent",
+  "  end while",
+  "end procedure",
+];
+
+function buildNodes(heap: number[]): BinaryTreeNode[] {
+  return heap.map((value, i) => ({
+    id: i,
+    value,
+    left: 2 * i + 1 < heap.length ? 2 * i + 1 : null,
+    right: 2 * i + 2 < heap.length ? 2 * i + 2 : null,
+  }));
+}
+
+function pushStep(
+  steps: TreeStep[],
+  heap: number[],
+  partial: Omit<TreeStep, "nodes" | "rootId">
+): void {
+  steps.push({
+    nodes: buildNodes(heap),
+    rootId: heap.length === 0 ? null : 0,
+    ...partial,
+  });
+}
+
+function siftUp(heap: number[], steps: TreeStep[], startIndex: number): void {
+  let i = startIndex;
+  while (i > 0) {
+    const parent = Math.floor((i - 1) / 2);
+    pushStep(steps, heap, {
+      current: i,
+      highlighted: [],
+      compared: [i, parent],
+      inserted: null,
+      message: `Comparing child ${heap[i]} with parent ${heap[parent]}.`,
+      lineNumber: 5,
+    });
+
+    if (heap[i]! >= heap[parent]!) {
+      pushStep(steps, heap, {
+        current: i,
+        highlighted: [i],
+        compared: [],
+        inserted: null,
+        message: `${heap[i]} ≥ ${heap[parent]}; heap property holds.`,
+        lineNumber: 6,
+      });
+      return;
+    }
+
+    [heap[i], heap[parent]] = [heap[parent]!, heap[i]!];
+    pushStep(steps, heap, {
+      current: parent,
+      highlighted: [parent],
+      compared: [],
+      inserted: null,
+      message: `Swapped; new value at index ${parent} is ${heap[parent]}.`,
+      lineNumber: 7,
+    });
+    i = parent;
+  }
+}
+
+function insertOne(heap: number[], steps: TreeStep[], value: number): void {
+  heap.push(value);
+  const lastIndex = heap.length - 1;
+  pushStep(steps, heap, {
+    current: lastIndex,
+    highlighted: [lastIndex],
+    compared: [],
+    inserted: lastIndex,
+    message: `Appending ${value} at index ${lastIndex}.`,
+    lineNumber: 1,
+  });
+  siftUp(heap, steps, lastIndex);
+}
+
+export function minHeapInsert(values: number[]): AlgorithmVisualization {
+  const heap: number[] = [];
+  const steps: TreeStep[] = [];
+
+  pushStep(steps, heap, {
+    current: null,
+    highlighted: [],
+    compared: [],
+    inserted: null,
+    message: "Starting with an empty min-heap.",
+    lineNumber: 0,
+  });
+
+  for (const value of values) {
+    insertOne(heap, steps, value);
+  }
+
+  pushStep(steps, heap, {
+    current: null,
+    highlighted: [],
+    compared: [],
+    inserted: null,
+    message: `Built min-heap with ${heap.length} node(s); root is ${heap[0]}.`,
+    lineNumber: 10,
+  });
+
+  return createVisualization("minHeapInsert", "tree-shape", steps, {
+    timeComplexity: "O(n log n)",
+    spaceComplexity: "O(n)",
+    reference: "https://en.wikipedia.org/wiki/Binary_heap",
+    pseudoCode: PSEUDO,
+  });
+}

--- a/lib/algorithms/dp/editDistance.ts
+++ b/lib/algorithms/dp/editDistance.ts
@@ -1,0 +1,198 @@
+import type {
+  AlgorithmVisualization,
+  GridCell,
+  GridStep,
+} from "../../types";
+import { createVisualization } from "../utils";
+
+const PSEUDO = [
+  "procedure editDistance(a, b)",
+  "  m := length(a); n := length(b)",
+  "  dp[0..m][0..n]",
+  "  for i in 0..m: dp[i][0] := i",
+  "  for j in 0..n: dp[0][j] := j",
+  "  for i in 1..m do",
+  "    for j in 1..n do",
+  "      if a[i-1] = b[j-1] then",
+  "        dp[i][j] := dp[i-1][j-1]",
+  "      else",
+  "        dp[i][j] := 1 + min(dp[i-1][j], dp[i][j-1], dp[i-1][j-1])",
+  "  return dp[m][n]",
+];
+
+function makeGrid(rows: number, cols: number): GridCell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => null as GridCell)
+  );
+}
+
+function copy(grid: GridCell[][]): GridCell[][] {
+  return grid.map((row) => [...row]);
+}
+
+function makeLabels(prefix: string, str: string): string[] {
+  return [prefix, ...str.split("")];
+}
+
+interface FillContext {
+  a: string;
+  b: string;
+  dp: GridCell[][];
+  steps: GridStep[];
+  rowLabels: string[];
+  colLabels: string[];
+}
+
+function pushStep(
+  ctx: FillContext,
+  partial: Omit<
+    GridStep,
+    "rows" | "cols" | "cells" | "rowLabels" | "colLabels"
+  >
+): void {
+  ctx.steps.push({
+    rows: ctx.dp.length,
+    cols: ctx.dp[0]!.length,
+    cells: copy(ctx.dp),
+    rowLabels: ctx.rowLabels,
+    colLabels: ctx.colLabels,
+    ...partial,
+  });
+}
+
+function fillBaseRow(ctx: FillContext): void {
+  for (let i = 0; i < ctx.dp.length; i++) {
+    ctx.dp[i]![0] = i;
+    pushStep(ctx, {
+      current: { row: i, col: 0 },
+      highlighted: [],
+      path: [],
+      message: `Base case: ${i} edits to convert empty to "${ctx.a.slice(0, i)}".`,
+      lineNumber: 3,
+    });
+  }
+}
+
+function fillBaseCol(ctx: FillContext): void {
+  for (let j = 1; j < ctx.dp[0]!.length; j++) {
+    ctx.dp[0]![j] = j;
+    pushStep(ctx, {
+      current: { row: 0, col: j },
+      highlighted: [],
+      path: [],
+      message: `Base case: ${j} edits to convert empty to "${ctx.b.slice(0, j)}".`,
+      lineNumber: 4,
+    });
+  }
+}
+
+function fillCell(ctx: FillContext, i: number, j: number): void {
+  const aChar = ctx.a[i - 1]!;
+  const bChar = ctx.b[j - 1]!;
+  const deps = [
+    { row: i - 1, col: j - 1 },
+    { row: i - 1, col: j },
+    { row: i, col: j - 1 },
+  ];
+  const diag = ctx.dp[i - 1]![j - 1]! as number;
+  if (aChar === bChar) {
+    ctx.dp[i]![j] = diag;
+    pushStep(ctx, {
+      current: { row: i, col: j },
+      highlighted: deps,
+      path: [],
+      message: `'${aChar}' = '${bChar}'; copy diagonal ${diag}.`,
+      lineNumber: 8,
+    });
+    return;
+  }
+  const up = ctx.dp[i - 1]![j]! as number;
+  const left = ctx.dp[i]![j - 1]! as number;
+  const value = 1 + Math.min(up, left, diag);
+  ctx.dp[i]![j] = value;
+  pushStep(ctx, {
+    current: { row: i, col: j },
+    highlighted: deps,
+    path: [],
+    message: `'${aChar}' ≠ '${bChar}'; 1 + min(${up}, ${left}, ${diag}) = ${value}.`,
+    lineNumber: 10,
+  });
+}
+
+function tracebackPath(ctx: FillContext): { row: number; col: number }[] {
+  const path: { row: number; col: number }[] = [];
+  let i = ctx.dp.length - 1;
+  let j = ctx.dp[0]!.length - 1;
+  while (i > 0 || j > 0) {
+    path.push({ row: i, col: j });
+    if (i === 0) {
+      j--;
+      continue;
+    }
+    if (j === 0) {
+      i--;
+      continue;
+    }
+    const diag = ctx.dp[i - 1]![j - 1]! as number;
+    const up = ctx.dp[i - 1]![j]! as number;
+    const left = ctx.dp[i]![j - 1]! as number;
+    const min = Math.min(diag, up, left);
+    if (diag === min) {
+      i--;
+      j--;
+    } else if (up === min) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+  path.push({ row: 0, col: 0 });
+  return path.reverse();
+}
+
+export function editDistance(a: string, b: string): AlgorithmVisualization {
+  const m = a.length;
+  const n = b.length;
+  const dp = makeGrid(m + 1, n + 1);
+  const ctx: FillContext = {
+    a,
+    b,
+    dp,
+    steps: [],
+    rowLabels: makeLabels("ε", a),
+    colLabels: makeLabels("ε", b),
+  };
+
+  pushStep(ctx, {
+    current: null,
+    highlighted: [],
+    path: [],
+    message: `Computing edit distance from "${a}" to "${b}".`,
+    lineNumber: 0,
+  });
+
+  fillBaseRow(ctx);
+  fillBaseCol(ctx);
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      fillCell(ctx, i, j);
+    }
+  }
+
+  const path = tracebackPath(ctx);
+  pushStep(ctx, {
+    current: { row: m, col: n },
+    highlighted: [],
+    path,
+    message: `Edit distance is ${dp[m]![n]}.`,
+    lineNumber: 11,
+  });
+
+  return createVisualization("editDistance", "grid-2d", ctx.steps, {
+    timeComplexity: "O(m·n)",
+    spaceComplexity: "O(m·n)",
+    reference: "https://en.wikipedia.org/wiki/Edit_distance",
+    pseudoCode: PSEUDO,
+  });
+}

--- a/lib/algorithms/dp/editDistance.ts
+++ b/lib/algorithms/dp/editDistance.ts
@@ -1,8 +1,4 @@
-import type {
-  AlgorithmVisualization,
-  GridCell,
-  GridStep,
-} from "../../types";
+import type { AlgorithmVisualization, GridCell, GridStep } from "../../types";
 import { createVisualization } from "../utils";
 
 const PSEUDO = [
@@ -45,10 +41,7 @@ interface FillContext {
 
 function pushStep(
   ctx: FillContext,
-  partial: Omit<
-    GridStep,
-    "rows" | "cols" | "cells" | "rowLabels" | "colLabels"
-  >
+  partial: Omit<GridStep, "rows" | "cols" | "cells" | "rowLabels" | "colLabels">
 ): void {
   ctx.steps.push({
     rows: ctx.dp.length,

--- a/lib/algorithms/dp/lcs.ts
+++ b/lib/algorithms/dp/lcs.ts
@@ -1,8 +1,4 @@
-import type {
-  AlgorithmVisualization,
-  GridCell,
-  GridStep,
-} from "../../types";
+import type { AlgorithmVisualization, GridCell, GridStep } from "../../types";
 import { createVisualization } from "../utils";
 
 const PSEUDO = [
@@ -43,10 +39,7 @@ interface FillContext {
 
 function pushStep(
   ctx: FillContext,
-  partial: Omit<
-    GridStep,
-    "rows" | "cols" | "cells" | "rowLabels" | "colLabels"
-  >
+  partial: Omit<GridStep, "rows" | "cols" | "cells" | "rowLabels" | "colLabels">
 ): void {
   ctx.steps.push({
     rows: ctx.dp.length,

--- a/lib/algorithms/dp/lcs.ts
+++ b/lib/algorithms/dp/lcs.ts
@@ -1,0 +1,158 @@
+import type {
+  AlgorithmVisualization,
+  GridCell,
+  GridStep,
+} from "../../types";
+import { createVisualization } from "../utils";
+
+const PSEUDO = [
+  "procedure lcs(a, b)",
+  "  m := length(a); n := length(b)",
+  "  dp[0..m][0..n] := 0",
+  "  for i in 1..m do",
+  "    for j in 1..n do",
+  "      if a[i-1] = b[j-1] then",
+  "        dp[i][j] := dp[i-1][j-1] + 1",
+  "      else",
+  "        dp[i][j] := max(dp[i-1][j], dp[i][j-1])",
+  "  return dp[m][n]",
+];
+
+function makeGrid(rows: number, cols: number): GridCell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => 0 as GridCell)
+  );
+}
+
+function copy(grid: GridCell[][]): GridCell[][] {
+  return grid.map((row) => [...row]);
+}
+
+function makeLabels(prefix: string, str: string): string[] {
+  return [prefix, ...str.split("")];
+}
+
+interface FillContext {
+  a: string;
+  b: string;
+  dp: GridCell[][];
+  steps: GridStep[];
+  rowLabels: string[];
+  colLabels: string[];
+}
+
+function pushStep(
+  ctx: FillContext,
+  partial: Omit<
+    GridStep,
+    "rows" | "cols" | "cells" | "rowLabels" | "colLabels"
+  >
+): void {
+  ctx.steps.push({
+    rows: ctx.dp.length,
+    cols: ctx.dp[0]!.length,
+    cells: copy(ctx.dp),
+    rowLabels: ctx.rowLabels,
+    colLabels: ctx.colLabels,
+    ...partial,
+  });
+}
+
+function fillCell(ctx: FillContext, i: number, j: number): void {
+  const aChar = ctx.a[i - 1]!;
+  const bChar = ctx.b[j - 1]!;
+  if (aChar === bChar) {
+    const v = (ctx.dp[i - 1]![j - 1]! as number) + 1;
+    ctx.dp[i]![j] = v;
+    pushStep(ctx, {
+      current: { row: i, col: j },
+      highlighted: [{ row: i - 1, col: j - 1 }],
+      path: [],
+      message: `'${aChar}' = '${bChar}'; extend LCS to ${v}.`,
+      lineNumber: 6,
+    });
+    return;
+  }
+  const up = ctx.dp[i - 1]![j]! as number;
+  const left = ctx.dp[i]![j - 1]! as number;
+  const v = Math.max(up, left);
+  ctx.dp[i]![j] = v;
+  pushStep(ctx, {
+    current: { row: i, col: j },
+    highlighted: [
+      { row: i - 1, col: j },
+      { row: i, col: j - 1 },
+    ],
+    path: [],
+    message: `'${aChar}' ≠ '${bChar}'; max(${up}, ${left}) = ${v}.`,
+    lineNumber: 8,
+  });
+}
+
+function tracebackPath(
+  a: string,
+  b: string,
+  dp: GridCell[][]
+): { row: number; col: number }[] {
+  const path: { row: number; col: number }[] = [];
+  let i = dp.length - 1;
+  let j = dp[0]!.length - 1;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      path.push({ row: i, col: j });
+      i--;
+      j--;
+      continue;
+    }
+    const up = dp[i - 1]![j]! as number;
+    const left = dp[i]![j - 1]! as number;
+    if (up >= left) i--;
+    else j--;
+  }
+  return path.reverse();
+}
+
+export function lcs(a: string, b: string): AlgorithmVisualization {
+  const m = a.length;
+  const n = b.length;
+  const dp = makeGrid(m + 1, n + 1);
+  const ctx: FillContext = {
+    a,
+    b,
+    dp,
+    steps: [],
+    rowLabels: makeLabels("ε", a),
+    colLabels: makeLabels("ε", b),
+  };
+
+  pushStep(ctx, {
+    current: null,
+    highlighted: [],
+    path: [],
+    message: `Computing LCS of "${a}" and "${b}".`,
+    lineNumber: 0,
+  });
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      fillCell(ctx, i, j);
+    }
+  }
+
+  const path = tracebackPath(a, b, dp);
+  const lcsLength = dp[m]![n] as number;
+  pushStep(ctx, {
+    current: { row: m, col: n },
+    highlighted: [],
+    path,
+    message: `LCS length is ${lcsLength}.`,
+    lineNumber: 9,
+  });
+
+  return createVisualization("lcs", "grid-2d", ctx.steps, {
+    timeComplexity: "O(m·n)",
+    spaceComplexity: "O(m·n)",
+    reference: "https://en.wikipedia.org/wiki/Longest_common_subsequence",
+    pseudoCode: PSEUDO,
+  });
+}

--- a/lib/algorithms/index.ts
+++ b/lib/algorithms/index.ts
@@ -16,6 +16,8 @@ import { prim } from "./graph/prim";
 import { kruskal } from "./graph/kruskal";
 import { bstInsert } from "./datastructure/bst";
 import { minHeapInsert } from "./datastructure/heap";
+import { editDistance } from "./dp/editDistance";
+import { lcs } from "./dp/lcs";
 
 export type SortingFn = (array: number[]) => AlgorithmVisualization;
 export type SearchFn = (
@@ -27,6 +29,7 @@ export type GraphFn = (
   startVertex?: number
 ) => AlgorithmVisualization;
 export type DataStructureFn = (values: number[]) => AlgorithmVisualization;
+export type DpFn = (a: string, b: string) => AlgorithmVisualization;
 
 const sortingAlgorithms = {
   bubbleSort,
@@ -57,15 +60,22 @@ const dataStructureAlgorithms = {
   minHeapInsert,
 } as const satisfies Record<string, DataStructureFn>;
 
+const dpAlgorithms = {
+  editDistance,
+  lcs,
+} as const satisfies Record<string, DpFn>;
+
 export type SortingAlgorithmName = keyof typeof sortingAlgorithms;
 export type SearchAlgorithmName = keyof typeof searchAlgorithms;
 export type GraphAlgorithmName = keyof typeof graphAlgorithms;
 export type DataStructureAlgorithmName = keyof typeof dataStructureAlgorithms;
+export type DpAlgorithmName = keyof typeof dpAlgorithms;
 export type AlgorithmName =
   | SortingAlgorithmName
   | SearchAlgorithmName
   | GraphAlgorithmName
-  | DataStructureAlgorithmName;
+  | DataStructureAlgorithmName
+  | DpAlgorithmName;
 
 export function isSortingAlgorithm(name: string): name is SortingAlgorithmName {
   return name in sortingAlgorithms;
@@ -85,12 +95,17 @@ export function isDataStructureAlgorithm(
   return name in dataStructureAlgorithms;
 }
 
+export function isDpAlgorithm(name: string): name is DpAlgorithmName {
+  return name in dpAlgorithms;
+}
+
 export function isAlgorithmName(name: string): name is AlgorithmName {
   return (
     isSortingAlgorithm(name) ||
     isSearchAlgorithm(name) ||
     isGraphAlgorithm(name) ||
-    isDataStructureAlgorithm(name)
+    isDataStructureAlgorithm(name) ||
+    isDpAlgorithm(name)
   );
 }
 
@@ -112,6 +127,10 @@ export function getDataStructureAlgorithm(
   return isDataStructureAlgorithm(name) ? dataStructureAlgorithms[name] : null;
 }
 
+export function getDpAlgorithm(name: string): DpFn | null {
+  return isDpAlgorithm(name) ? dpAlgorithms[name] : null;
+}
+
 export {
   bubbleSort,
   selectionSort,
@@ -130,4 +149,6 @@ export {
   kruskal,
   bstInsert,
   minHeapInsert,
+  editDistance,
+  lcs,
 };

--- a/lib/algorithms/index.ts
+++ b/lib/algorithms/index.ts
@@ -14,6 +14,8 @@ import { topologicalSort } from "./graph/topologicalSort";
 import { bellmanFord } from "./graph/bellmanFord";
 import { prim } from "./graph/prim";
 import { kruskal } from "./graph/kruskal";
+import { bstInsert } from "./datastructure/bst";
+import { minHeapInsert } from "./datastructure/heap";
 
 export type SortingFn = (array: number[]) => AlgorithmVisualization;
 export type SearchFn = (
@@ -24,6 +26,7 @@ export type GraphFn = (
   graph: Graph,
   startVertex?: number
 ) => AlgorithmVisualization;
+export type DataStructureFn = (values: number[]) => AlgorithmVisualization;
 
 const sortingAlgorithms = {
   bubbleSort,
@@ -49,13 +52,20 @@ const graphAlgorithms = {
   kruskal,
 } as const satisfies Record<string, GraphFn>;
 
+const dataStructureAlgorithms = {
+  bstInsert,
+  minHeapInsert,
+} as const satisfies Record<string, DataStructureFn>;
+
 export type SortingAlgorithmName = keyof typeof sortingAlgorithms;
 export type SearchAlgorithmName = keyof typeof searchAlgorithms;
 export type GraphAlgorithmName = keyof typeof graphAlgorithms;
+export type DataStructureAlgorithmName = keyof typeof dataStructureAlgorithms;
 export type AlgorithmName =
   | SortingAlgorithmName
   | SearchAlgorithmName
-  | GraphAlgorithmName;
+  | GraphAlgorithmName
+  | DataStructureAlgorithmName;
 
 export function isSortingAlgorithm(name: string): name is SortingAlgorithmName {
   return name in sortingAlgorithms;
@@ -69,11 +79,18 @@ export function isGraphAlgorithm(name: string): name is GraphAlgorithmName {
   return name in graphAlgorithms;
 }
 
+export function isDataStructureAlgorithm(
+  name: string
+): name is DataStructureAlgorithmName {
+  return name in dataStructureAlgorithms;
+}
+
 export function isAlgorithmName(name: string): name is AlgorithmName {
   return (
     isSortingAlgorithm(name) ||
     isSearchAlgorithm(name) ||
-    isGraphAlgorithm(name)
+    isGraphAlgorithm(name) ||
+    isDataStructureAlgorithm(name)
   );
 }
 
@@ -87,6 +104,12 @@ export function getSearchAlgorithm(name: string): SearchFn | null {
 
 export function getGraphAlgorithm(name: string): GraphFn | null {
   return isGraphAlgorithm(name) ? graphAlgorithms[name] : null;
+}
+
+export function getDataStructureAlgorithm(
+  name: string
+): DataStructureFn | null {
+  return isDataStructureAlgorithm(name) ? dataStructureAlgorithms[name] : null;
 }
 
 export {
@@ -105,4 +128,6 @@ export {
   bellmanFord,
   prim,
   kruskal,
+  bstInsert,
+  minHeapInsert,
 };

--- a/lib/algorithms/metadata.ts
+++ b/lib/algorithms/metadata.ts
@@ -141,4 +141,22 @@ export const availableAlgorithms: Record<string, AlgorithmInfo> = {
       "Kruskal's algorithm builds a minimum spanning tree (MST) by sorting all edges by weight and adding them one at a time, skipping any edge that would form a cycle. A disjoint-set (union-find) data structure makes the cycle check efficient. Unlike Prim's, Kruskal's grows the tree as a forest of components that gradually merge, making it well-suited to sparse graphs. It's used in network design, image segmentation, and as a building block for clustering algorithms.",
     difficulty: "medium",
   },
+  bstInsert: {
+    name: "Binary Search Tree (Insert)",
+    key: "bstInsert",
+    category: "datastructure",
+    subtitle: "Build a BST by inserting values one at a time",
+    description:
+      "A binary search tree (BST) maintains the invariant that every node's left subtree contains only smaller values and its right subtree only larger values. Inserting a value walks the tree from the root, branching left or right at each node by comparison, until it reaches a missing child where the new node is attached. Average insertion is O(log n) when the tree is balanced; the worst case degrades to O(n) when input order produces a skewed tree, motivating self-balancing variants like AVL and red-black trees.",
+    difficulty: "medium",
+  },
+  minHeapInsert: {
+    name: "Min-Heap (Insert)",
+    key: "minHeapInsert",
+    category: "datastructure",
+    subtitle: "Build a min-heap by inserting and sifting up",
+    description:
+      "A binary min-heap is a complete binary tree where every parent is less than or equal to its children. Stored as an array, the children of index i live at 2i+1 and 2i+2, so the structure stays compact without explicit pointers. Each insertion appends the new value at the end and 'sifts up' — repeatedly swapping it with its parent while the parent is larger — restoring the heap property in O(log n). Heaps are the backbone of priority queues, heap sort, and shortest-path algorithms like Dijkstra's.",
+    difficulty: "medium",
+  },
 };

--- a/lib/algorithms/metadata.ts
+++ b/lib/algorithms/metadata.ts
@@ -159,4 +159,22 @@ export const availableAlgorithms: Record<string, AlgorithmInfo> = {
       "A binary min-heap is a complete binary tree where every parent is less than or equal to its children. Stored as an array, the children of index i live at 2i+1 and 2i+2, so the structure stays compact without explicit pointers. Each insertion appends the new value at the end and 'sifts up' — repeatedly swapping it with its parent while the parent is larger — restoring the heap property in O(log n). Heaps are the backbone of priority queues, heap sort, and shortest-path algorithms like Dijkstra's.",
     difficulty: "medium",
   },
+  editDistance: {
+    name: "Edit Distance",
+    key: "editDistance",
+    category: "dp",
+    subtitle: "Levenshtein distance via bottom-up DP table",
+    description:
+      "Edit distance — also called Levenshtein distance — measures the minimum number of single-character insertions, deletions, or substitutions needed to turn one string into another. The classic dynamic-programming solution fills an (m+1)×(n+1) table where dp[i][j] is the cost to transform the first i characters of one string into the first j of the other. Each cell depends only on its top, left, and top-left neighbours, so the table fills row-by-row in O(m·n). The traceback through the dependencies reconstructs an optimal edit script. Variants underpin spell-checkers, DNA alignment, and diff tools.",
+    difficulty: "hard",
+  },
+  lcs: {
+    name: "Longest Common Subsequence",
+    key: "lcs",
+    category: "dp",
+    subtitle: "Find the longest subsequence shared by two strings",
+    description:
+      "The longest common subsequence (LCS) of two sequences is the longest sequence appearing in both as a subsequence — preserving order but not contiguity. The standard dynamic-programming solution fills an (m+1)×(n+1) table where dp[i][j] is the LCS length of the first i and j characters. When characters match, the cell extends the diagonal by one; otherwise it inherits the larger of its top and left neighbours. The table fills in O(m·n), and a traceback recovers the actual subsequence. LCS is the workhorse behind Unix `diff`, version control merge, and computational biology sequence alignment.",
+    difficulty: "medium",
+  },
 };

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -38,7 +38,50 @@ export interface GraphStep {
   lineNumber?: number;
 }
 
-export type PrimitiveKind = "array-bars" | "array-cells" | "graph-2d";
+export interface BinaryTreeNode {
+  id: number;
+  value: number;
+  left: number | null;
+  right: number | null;
+}
+
+export interface TreeStep {
+  nodes: BinaryTreeNode[];
+  rootId: number | null;
+  current: number | null;
+  highlighted: number[];
+  compared: number[];
+  inserted: number | null;
+  message: string;
+  lineNumber?: number;
+}
+
+export type GridCell = number | string | null;
+
+export interface GridCoord {
+  row: number;
+  col: number;
+}
+
+export interface GridStep {
+  rows: number;
+  cols: number;
+  cells: GridCell[][];
+  current: GridCoord | null;
+  highlighted: GridCoord[];
+  path: GridCoord[];
+  rowLabels: string[];
+  colLabels: string[];
+  message: string;
+  lineNumber?: number;
+}
+
+export type PrimitiveKind =
+  | "array-bars"
+  | "array-cells"
+  | "graph-2d"
+  | "tree-shape"
+  | "grid-2d";
 
 export type StepsForPrimitive<P extends PrimitiveKind> = P extends "array-bars"
   ? SortingStep[]
@@ -46,12 +89,18 @@ export type StepsForPrimitive<P extends PrimitiveKind> = P extends "array-bars"
     ? SearchStep[]
     : P extends "graph-2d"
       ? GraphStep[]
-      : never;
+      : P extends "tree-shape"
+        ? TreeStep[]
+        : P extends "grid-2d"
+          ? GridStep[]
+          : never;
 
 type PrimitiveBinding =
   | { primitive: "array-bars"; steps: SortingStep[] }
   | { primitive: "array-cells"; steps: SearchStep[] }
-  | { primitive: "graph-2d"; steps: GraphStep[] };
+  | { primitive: "graph-2d"; steps: GraphStep[] }
+  | { primitive: "tree-shape"; steps: TreeStep[] }
+  | { primitive: "grid-2d"; steps: GridStep[] };
 
 export type AlgorithmVisualization = PrimitiveBinding & {
   name: string;
@@ -69,7 +118,8 @@ export type AlgorithmCategory =
   | "sorting"
   | "searching"
   | "graph"
-  | "datastructure";
+  | "datastructure"
+  | "dp";
 
 export interface AlgorithmInfo {
   name: string;


### PR DESCRIPTION
## Summary

Builds out the next three phases of the project vision in one PR, four focused commits:

- **Phase 5 — Visual primitives foundation.** Adds `TreePrimitive` (binary-tree SVG layout) and `GridPrimitive` (DP-table grid) under `components/visualizer/primitives/`, plus a line-synced `AlgorithmPseudocode` that highlights the line tied to the current step's `pseudoLine`. New `TreeStep` / `GridStep` types and two new `AlgorithmCategory` values (`datastructure`, `dp`).
- **Phase 6 — Data structures.** First two algorithms on `TreePrimitive`: `bstInsert` (BST built one value at a time, with comparison-by-comparison narration) and `minHeapInsert` (append + sift-up). New `/datastructure` category page and `/datastructure/[algorithm]` dynamic route.
- **Phase 7 — Dynamic programming.** First two DP algorithms on `GridPrimitive`: `editDistance` (Levenshtein with traceback) and `lcs` (longest common subsequence with traceback). New `StringPairInputPanel` for two-string inputs, `/dp` listing page, and `/dp/[algorithm]` dynamic route with URL-synced strings (query params `a` and `b`).
- **Wiring.** Navbar, home page (explicit category label map and ordering), sitemap, and `GROWTH.md` snapshot updated for the new categories.

19 algorithms across 5 categories; 164 tests in 14 files (statement coverage 56.34%). Lint, type-check, and `next build` all clean.

## Test plan

- [ ] `npm run lint`
- [ ] `npx tsc --noEmit`
- [ ] `npm test` (164 tests)
- [ ] `npm run build`
- [ ] Visit `/` and confirm Data Structures and Dynamic Programming sections render with proper labels
- [ ] Visit `/datastructure/bstInsert`, step through insertion of a random array, confirm pseudocode line highlights track the step
- [ ] Visit `/datastructure/minHeapInsert` and confirm sift-up swaps animate in the tree
- [ ] Visit `/dp/editDistance`, try the default kitten/sitting and confirm distance is 3, traceback path highlights
- [ ] Visit `/dp/lcs`, try AGCAT/GAC and confirm LCS length is 2
- [ ] Set strings in `/dp/editDistance` then reload; confirm `a` and `b` query params restore them
- [ ] Confirm existing sorting/searching/graph routes are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
