### PR TITLE
Phase 8: A*, grid Dijkstra, and recursive-backtracker maze

### DIFF
--- a/GROWTH.md
+++ b/GROWTH.md
@@ -12,6 +12,62 @@ Copy the template at the bottom of this file, fill it in, and prepend it to the 
 
 ## Snapshots
 
+### 2026-05-10 — After Phase 8: pathfinding & spatial on the grid
+
+**Trigger:** Phase 8 pathfinding and maze generation on `Grid2D`. Adds A*, Dijkstra-on-grid, and a recursive-backtracker maze generator. New `pathfinding` category, new grid input panel with click-to-edit walls/start/goal, URL-shareable grid configurations.
+
+#### Algorithms
+
+| Category        | Count  | Names                                                                    |
+| --------------- | ------ | ------------------------------------------------------------------------ |
+| Sorting         | 6      | bubbleSort, selectionSort, insertionSort, mergeSort, quickSort, heapSort |
+| Searching       | 2      | linearSearch, binarySearch                                               |
+| Graph           | 7      | bfs, dfs, dijkstra, topologicalSort, bellmanFord, prim, kruskal          |
+| Data Structures | 2      | bstInsert, minHeapInsert                                                 |
+| Dynamic Prog.   | 2      | editDistance, lcs                                                        |
+| Pathfinding     | 3      | aStar, dijkstraGrid, mazeRecursiveBacktracker                            |
+| **Total**       | **22** |                                                                          |
+
+Difficulty breakdown: easy × 4, medium × 14, hard × 4
+
+#### Test suite
+
+| Metric     | Count |
+| ---------- | ----- |
+| Test files | 15    |
+| Test cases | 176   |
+
+New test file:
+
+- `__tests__/lib/algorithms/pathfinding/pathfinding.test.ts` — A* / Dijkstra optimality, wall routing, unreachable goals, maze invariants
+
+#### Pages & routes
+
+New routes: `/pathfinding`, `/pathfinding/[algorithm]`. Sitemap entries added; navbar link added.
+
+#### Components
+
+New: `components/visualizer/GridInputPanel.tsx` — click-to-edit grid with wall/start/goal modes, resize controls, randomize/clear buttons. `Grid2D` primitive extended to render walls, start, goal, frontier (open set), and visited (closed set) on top of the existing DP grid contract.
+
+`ColorLegend` gained a pathfinding-specific palette.
+
+#### Source code
+
+| Metric                                   | Count   |
+| ---------------------------------------- | ------- |
+| TypeScript/TSX files                     | 83      |
+| Total lines (lib+components+context+app) | ~5,018  |
+
+#### Notes
+
+- **Step shape evolution:** `GridStep` gained optional `walls`, `start`, `goal`, `frontier`, `visited` fields. DP code is untouched — it just doesn't populate them. Pathfinding uses all five.
+- **PathfindingFn signature:** `(input: PathfindingInput) => AlgorithmVisualization`, with `PathfindingInput = { rows, cols, start, goal, walls }`. Maze generation uses the same signature even though it ignores walls (it produces them).
+- **A\* heuristic:** Manhattan distance — admissible and consistent on a 4-connected grid with unit costs.
+- **Maze gen seed:** uses a deterministic Mulberry32 PRNG so visualizations are reproducible across reloads. (To re-randomize on demand, the route would need to thread a fresh seed.)
+- **URL state:** grid config encodes as `?r=N&c=M&s=row,col&g=row,col&w=r,c;r,c;…`. Resize clamps walls/start/goal into bounds.
+
+---
+
 ### 2026-05-10 — After Phases 6 & 7: data structures and DP on the new primitives
 
 **Trigger:** Phase 6 data structures (BST insert, min-heap insert) and Phase 7 dynamic programming (Edit Distance, LCS) layered on top of the Phase 5 visual-primitives architecture. Two new primitives — TreeShape and Grid2D — extend the existing array-bars / array-cells / graph-2d set.

--- a/GROWTH.md
+++ b/GROWTH.md
@@ -14,7 +14,7 @@ Copy the template at the bottom of this file, fill it in, and prepend it to the 
 
 ### 2026-05-10 — After Phase 8: pathfinding & spatial on the grid
 
-**Trigger:** Phase 8 pathfinding and maze generation on `Grid2D`. Adds A*, Dijkstra-on-grid, and a recursive-backtracker maze generator. New `pathfinding` category, new grid input panel with click-to-edit walls/start/goal, URL-shareable grid configurations.
+**Trigger:** Phase 8 pathfinding and maze generation on `Grid2D`. Adds A\*, Dijkstra-on-grid, and a recursive-backtracker maze generator. New `pathfinding` category, new grid input panel with click-to-edit walls/start/goal, URL-shareable grid configurations.
 
 #### Algorithms
 
@@ -39,7 +39,7 @@ Difficulty breakdown: easy × 4, medium × 14, hard × 4
 
 New test file:
 
-- `__tests__/lib/algorithms/pathfinding/pathfinding.test.ts` — A* / Dijkstra optimality, wall routing, unreachable goals, maze invariants
+- `__tests__/lib/algorithms/pathfinding/pathfinding.test.ts` — A\* / Dijkstra optimality, wall routing, unreachable goals, maze invariants
 
 #### Pages & routes
 
@@ -53,10 +53,10 @@ New: `components/visualizer/GridInputPanel.tsx` — click-to-edit grid with wall
 
 #### Source code
 
-| Metric                                   | Count   |
-| ---------------------------------------- | ------- |
-| TypeScript/TSX files                     | 83      |
-| Total lines (lib+components+context+app) | ~5,018  |
+| Metric                                   | Count  |
+| ---------------------------------------- | ------ |
+| TypeScript/TSX files                     | 83     |
+| Total lines (lib+components+context+app) | ~5,018 |
 
 #### Notes
 

--- a/__tests__/lib/algorithms/index.test.ts
+++ b/__tests__/lib/algorithms/index.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
   getGraphAlgorithm,
+  getPathfindingAlgorithm,
   getSearchAlgorithm,
   getSortingAlgorithm,
   isAlgorithmName,
   isGraphAlgorithm,
+  isPathfindingAlgorithm,
   isSearchAlgorithm,
   isSortingAlgorithm,
 } from "@/lib/algorithms";
@@ -50,6 +52,26 @@ describe("getGraphAlgorithm", () => {
   });
 });
 
+describe("getPathfindingAlgorithm", () => {
+  it("returns the function for a known pathfinding algorithm", () => {
+    const fn = getPathfindingAlgorithm("aStar");
+    expect(fn).toBeTypeOf("function");
+    const viz = fn!({
+      rows: 4,
+      cols: 4,
+      start: { row: 0, col: 0 },
+      goal: { row: 3, col: 3 },
+      walls: [],
+    });
+    expect(viz.key).toBe("aStar");
+  });
+
+  it("returns null for non-pathfinding names", () => {
+    expect(getPathfindingAlgorithm("bubbleSort")).toBeNull();
+    expect(getPathfindingAlgorithm("madeUp")).toBeNull();
+  });
+});
+
 describe("category guards", () => {
   it("classify known algorithm keys correctly", () => {
     expect(isSortingAlgorithm("bubbleSort")).toBe(true);
@@ -61,12 +83,17 @@ describe("category guards", () => {
     expect(isGraphAlgorithm("prim")).toBe(true);
     expect(isGraphAlgorithm("kruskal")).toBe(true);
     expect(isGraphAlgorithm("bubbleSort")).toBe(false);
+    expect(isPathfindingAlgorithm("aStar")).toBe(true);
+    expect(isPathfindingAlgorithm("dijkstraGrid")).toBe(true);
+    expect(isPathfindingAlgorithm("mazeRecursiveBacktracker")).toBe(true);
+    expect(isPathfindingAlgorithm("dfs")).toBe(false);
   });
 
   it("isAlgorithmName accepts all categories and rejects unknown", () => {
     expect(isAlgorithmName("dfs")).toBe(true);
     expect(isAlgorithmName("bubbleSort")).toBe(true);
     expect(isAlgorithmName("linearSearch")).toBe(true);
+    expect(isAlgorithmName("aStar")).toBe(true);
     expect(isAlgorithmName("nope")).toBe(false);
     expect(isAlgorithmName("")).toBe(false);
   });

--- a/__tests__/lib/algorithms/pathfinding/pathfinding.test.ts
+++ b/__tests__/lib/algorithms/pathfinding/pathfinding.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { aStar } from "@/lib/algorithms/pathfinding/aStar";
+import { dijkstraGrid } from "@/lib/algorithms/pathfinding/dijkstraGrid";
+import { mazeRecursiveBacktracker } from "@/lib/algorithms/pathfinding/mazeRecursiveBacktracker";
+import type { PathfindingInput } from "@/lib/algorithms/pathfinding/grid";
+import type { AlgorithmVisualization, GridCoord, GridStep } from "@/lib/types";
+
+function input(overrides: Partial<PathfindingInput> = {}): PathfindingInput {
+  return {
+    rows: 5,
+    cols: 5,
+    start: { row: 0, col: 0 },
+    goal: { row: 4, col: 4 },
+    walls: [],
+    ...overrides,
+  };
+}
+
+function lastStep(viz: AlgorithmVisualization): GridStep {
+  return viz.steps[viz.steps.length - 1] as GridStep;
+}
+
+function pathContains(path: GridCoord[], c: GridCoord): boolean {
+  return path.some((p) => p.row === c.row && p.col === c.col);
+}
+
+describe("aStar", () => {
+  it("returns metadata bound to grid-2d", () => {
+    const viz = aStar(input());
+    expect(viz.key).toBe("aStar");
+    expect(viz.category).toBe("pathfinding");
+    expect(viz.primitive).toBe("grid-2d");
+    expect(viz.steps.length).toBeGreaterThan(0);
+  });
+
+  it("finds a path of optimal length on an empty grid", () => {
+    const viz = aStar(input());
+    const last = lastStep(viz);
+    expect(last.path.length).toBe(9);
+    expect(pathContains(last.path, { row: 0, col: 0 })).toBe(true);
+    expect(pathContains(last.path, { row: 4, col: 4 })).toBe(true);
+  });
+
+  it("routes around a wall barrier", () => {
+    const walls: GridCoord[] = [
+      { row: 0, col: 2 },
+      { row: 1, col: 2 },
+      { row: 2, col: 2 },
+      { row: 3, col: 2 },
+    ];
+    const viz = aStar(input({ walls }));
+    const last = lastStep(viz);
+    expect(last.path.length).toBeGreaterThan(0);
+    for (const w of walls) {
+      expect(pathContains(last.path, w)).toBe(false);
+    }
+  });
+
+  it("reports failure when goal is walled in", () => {
+    const walls: GridCoord[] = [
+      { row: 3, col: 4 },
+      { row: 4, col: 3 },
+    ];
+    const viz = aStar(input({ walls }));
+    const last = lastStep(viz);
+    expect(last.path.length).toBe(0);
+    expect(last.message.toLowerCase()).toContain("no path");
+  });
+
+  it("trivially succeeds when start equals goal", () => {
+    const viz = aStar(input({ goal: { row: 0, col: 0 } }));
+    const last = lastStep(viz);
+    expect(last.path.length).toBe(1);
+  });
+});
+
+describe("dijkstraGrid", () => {
+  it("returns metadata bound to grid-2d", () => {
+    const viz = dijkstraGrid(input());
+    expect(viz.key).toBe("dijkstraGrid");
+    expect(viz.primitive).toBe("grid-2d");
+  });
+
+  it("finds optimal path on empty grid", () => {
+    const viz = dijkstraGrid(input());
+    const last = lastStep(viz);
+    expect(last.path.length).toBe(9);
+  });
+
+  it("matches A* path length when both are optimal", () => {
+    const walls: GridCoord[] = [{ row: 2, col: 2 }];
+    const a = lastStep(aStar(input({ walls })));
+    const d = lastStep(dijkstraGrid(input({ walls })));
+    expect(a.path.length).toBe(d.path.length);
+  });
+
+  it("reports failure when goal is unreachable", () => {
+    const walls: GridCoord[] = [
+      { row: 3, col: 4 },
+      { row: 4, col: 3 },
+    ];
+    const viz = dijkstraGrid(input({ walls }));
+    const last = lastStep(viz);
+    expect(last.path.length).toBe(0);
+  });
+});
+
+describe("mazeRecursiveBacktracker", () => {
+  it("returns metadata bound to grid-2d", () => {
+    const viz = mazeRecursiveBacktracker(input({ rows: 7, cols: 7 }));
+    expect(viz.key).toBe("mazeRecursiveBacktracker");
+    expect(viz.primitive).toBe("grid-2d");
+    expect(viz.steps.length).toBeGreaterThan(1);
+  });
+
+  it("carves at least one passage on a 7x7 grid", () => {
+    const viz = mazeRecursiveBacktracker(input({ rows: 7, cols: 7 }));
+    const last = lastStep(viz);
+    expect(last.visited?.length ?? 0).toBeGreaterThan(1);
+    const wallCount = last.walls?.length ?? 0;
+    expect(wallCount).toBeGreaterThan(0);
+    expect(wallCount).toBeLessThan(7 * 7);
+  });
+
+  it("carved cells and wall cells are disjoint", () => {
+    const viz = mazeRecursiveBacktracker(input({ rows: 7, cols: 7 }));
+    const last = lastStep(viz);
+    const wallSet = new Set(
+      (last.walls ?? []).map((w) => `${w.row}:${w.col}`)
+    );
+    for (const c of last.visited ?? []) {
+      expect(wallSet.has(`${c.row}:${c.col}`)).toBe(false);
+    }
+  });
+});

--- a/__tests__/lib/algorithms/pathfinding/pathfinding.test.ts
+++ b/__tests__/lib/algorithms/pathfinding/pathfinding.test.ts
@@ -125,9 +125,7 @@ describe("mazeRecursiveBacktracker", () => {
   it("carved cells and wall cells are disjoint", () => {
     const viz = mazeRecursiveBacktracker(input({ rows: 7, cols: 7 }));
     const last = lastStep(viz);
-    const wallSet = new Set(
-      (last.walls ?? []).map((w) => `${w.row}:${w.col}`)
-    );
+    const wallSet = new Set((last.walls ?? []).map((w) => `${w.row}:${w.col}`));
     for (const c of last.visited ?? []) {
       expect(wallSet.has(`${c.row}:${c.col}`)).toBe(false);
     }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ const CATEGORY_LABELS: Record<AlgorithmCategory, string> = {
   graph: "Graph Algorithms",
   datastructure: "Data Structures",
   dp: "Dynamic Programming",
+  pathfinding: "Pathfinding & Spatial",
 };
 
 const CATEGORY_ORDER: AlgorithmCategory[] = [
@@ -18,6 +19,7 @@ const CATEGORY_ORDER: AlgorithmCategory[] = [
   "graph",
   "datastructure",
   "dp",
+  "pathfinding",
 ];
 
 export default function Home() {

--- a/app/pathfinding/[algorithm]/page.tsx
+++ b/app/pathfinding/[algorithm]/page.tsx
@@ -82,13 +82,19 @@ function configFromParams(
         row: clampInt(startRaw.row, 0, rows - 1, fallback.start.row),
         col: clampInt(startRaw.col, 0, cols - 1, fallback.start.col),
       }
-    : { row: Math.min(fallback.start.row, rows - 1), col: Math.min(fallback.start.col, cols - 1) };
+    : {
+        row: Math.min(fallback.start.row, rows - 1),
+        col: Math.min(fallback.start.col, cols - 1),
+      };
   const goal: GridCoord = goalRaw
     ? {
         row: clampInt(goalRaw.row, 0, rows - 1, fallback.goal.row),
         col: clampInt(goalRaw.col, 0, cols - 1, fallback.goal.col),
       }
-    : { row: Math.min(fallback.goal.row, rows - 1), col: Math.min(fallback.goal.col, cols - 1) };
+    : {
+        row: Math.min(fallback.goal.row, rows - 1),
+        col: Math.min(fallback.goal.col, cols - 1),
+      };
   const walls = (wallsRaw ?? fallback.walls).filter(
     (w) => w.row < rows && w.col < cols
   );

--- a/app/pathfinding/[algorithm]/page.tsx
+++ b/app/pathfinding/[algorithm]/page.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { Suspense, useCallback, useEffect, useRef, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import PageLayout from "@/components/layout/PageLayout";
+import AlgorithmVisualizer from "@/components/visualizer/AlgorithmVisualizer";
+import GridInputPanel from "@/components/visualizer/GridInputPanel";
+import { useAlgorithm } from "@/context/AlgorithmContext";
+import { getPathfindingAlgorithm } from "@/lib/algorithms";
+import { availableAlgorithms } from "@/lib/algorithms/metadata";
+import type { GridCoord } from "@/lib/types";
+
+interface GridConfig {
+  rows: number;
+  cols: number;
+  start: GridCoord;
+  goal: GridCoord;
+  walls: GridCoord[];
+}
+
+const DEFAULT_ROWS = 11;
+const DEFAULT_COLS = 15;
+
+function defaultConfig(): GridConfig {
+  return {
+    rows: DEFAULT_ROWS,
+    cols: DEFAULT_COLS,
+    start: { row: 5, col: 1 },
+    goal: { row: 5, col: 13 },
+    walls: [
+      { row: 2, col: 7 },
+      { row: 3, col: 7 },
+      { row: 4, col: 7 },
+      { row: 5, col: 7 },
+      { row: 6, col: 7 },
+      { row: 7, col: 7 },
+      { row: 8, col: 7 },
+    ],
+  };
+}
+
+function clampInt(
+  value: number | null,
+  min: number,
+  max: number,
+  fallback: number
+): number {
+  if (value === null || !Number.isFinite(value)) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(value)));
+}
+
+function parseCoord(raw: string | null): GridCoord | null {
+  if (!raw) return null;
+  const [r, c] = raw.split(",").map((s) => Number(s));
+  if (!Number.isFinite(r) || !Number.isFinite(c)) return null;
+  return { row: r as number, col: c as number };
+}
+
+function parseWalls(raw: string | null): GridCoord[] | null {
+  if (!raw) return null;
+  if (raw.trim() === "") return [];
+  const out: GridCoord[] = [];
+  for (const part of raw.split(";")) {
+    const coord = parseCoord(part);
+    if (!coord) return null;
+    out.push(coord);
+  }
+  return out;
+}
+
+function configFromParams(
+  params: URLSearchParams,
+  fallback: GridConfig
+): GridConfig {
+  const rows = clampInt(Number(params.get("r")), 5, 25, fallback.rows);
+  const cols = clampInt(Number(params.get("c")), 5, 25, fallback.cols);
+  const startRaw = parseCoord(params.get("s"));
+  const goalRaw = parseCoord(params.get("g"));
+  const wallsRaw = parseWalls(params.get("w"));
+  const start: GridCoord = startRaw
+    ? {
+        row: clampInt(startRaw.row, 0, rows - 1, fallback.start.row),
+        col: clampInt(startRaw.col, 0, cols - 1, fallback.start.col),
+      }
+    : { row: Math.min(fallback.start.row, rows - 1), col: Math.min(fallback.start.col, cols - 1) };
+  const goal: GridCoord = goalRaw
+    ? {
+        row: clampInt(goalRaw.row, 0, rows - 1, fallback.goal.row),
+        col: clampInt(goalRaw.col, 0, cols - 1, fallback.goal.col),
+      }
+    : { row: Math.min(fallback.goal.row, rows - 1), col: Math.min(fallback.goal.col, cols - 1) };
+  const walls = (wallsRaw ?? fallback.walls).filter(
+    (w) => w.row < rows && w.col < cols
+  );
+  return { rows, cols, start, goal, walls };
+}
+
+function configToParams(cfg: GridConfig): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set("r", String(cfg.rows));
+  params.set("c", String(cfg.cols));
+  params.set("s", `${cfg.start.row},${cfg.start.col}`);
+  params.set("g", `${cfg.goal.row},${cfg.goal.col}`);
+  params.set("w", cfg.walls.map((w) => `${w.row},${w.col}`).join(";"));
+  return params;
+}
+
+function randomWalls(rows: number, cols: number, density: number): GridCoord[] {
+  const walls: GridCoord[] = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (Math.random() < density) walls.push({ row: r, col: c });
+    }
+  }
+  return walls;
+}
+
+function randomizeWalls(prev: GridConfig): GridConfig {
+  const walls = randomWalls(prev.rows, prev.cols, 0.22).filter(
+    (w) =>
+      !(w.row === prev.start.row && w.col === prev.start.col) &&
+      !(w.row === prev.goal.row && w.col === prev.goal.col)
+  );
+  return { ...prev, walls };
+}
+
+function clearWalls(prev: GridConfig): GridConfig {
+  return { ...prev, walls: [] };
+}
+
+function PathfindingPageInner() {
+  const params = useParams();
+  const algorithmKey = params.algorithm as string;
+  const { dispatch } = useAlgorithm();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const initializedFromUrl = useRef(false);
+
+  const algorithmInfo = availableAlgorithms[algorithmKey];
+
+  const [config, setConfig] = useState<GridConfig>(defaultConfig);
+
+  useEffect(() => {
+    if (initializedFromUrl.current) return;
+    initializedFromUrl.current = true;
+    setConfig(configFromParams(searchParams, defaultConfig()));
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!algorithmKey) return;
+    dispatch({ type: "SET_ALGORITHM", payload: algorithmKey });
+    const fn = getPathfindingAlgorithm(algorithmKey);
+    if (!fn) return;
+    try {
+      const viz = fn(config);
+      dispatch({ type: "GENERATE_VISUALIZATION", payload: viz });
+    } catch (error) {
+      console.error("Error generating visualization:", error);
+    }
+  }, [algorithmKey, config, dispatch]);
+
+  useEffect(() => {
+    router.replace(`?${configToParams(config).toString()}`, { scroll: false });
+  }, [config, router]);
+
+  const handleRandomize = useCallback(() => {
+    setConfig(randomizeWalls);
+  }, []);
+
+  const handleClearWalls = useCallback(() => {
+    setConfig(clearWalls);
+  }, []);
+
+  if (!algorithmInfo) {
+    return (
+      <PageLayout title="Algorithm Not Found">
+        <div className="py-12 text-center">
+          <h2 className="heading-lg text-red-600">Algorithm Not Found</h2>
+          <p className="mt-4 text-gray-600">
+            The algorithm you are looking for does not exist or is not
+            available.
+          </p>
+        </div>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout title={algorithmInfo.name} subtitle={algorithmInfo.subtitle}>
+      <div className="mb-6">
+        <GridInputPanel
+          rows={config.rows}
+          cols={config.cols}
+          start={config.start}
+          goal={config.goal}
+          walls={config.walls}
+          onChange={setConfig}
+          onRandomize={handleRandomize}
+          onClearWalls={handleClearWalls}
+        />
+      </div>
+      <AlgorithmVisualizer />
+    </PageLayout>
+  );
+}
+
+export default function PathfindingAlgorithmPage() {
+  return (
+    <Suspense>
+      <PathfindingPageInner />
+    </Suspense>
+  );
+}

--- a/app/pathfinding/page.tsx
+++ b/app/pathfinding/page.tsx
@@ -1,0 +1,22 @@
+import PageLayout from "@/components/layout/PageLayout";
+import AlgorithmCard from "@/components/AlgorithmCard";
+import { availableAlgorithms } from "@/lib/algorithms/metadata";
+
+export default function PathfindingAlgorithms() {
+  const pathfindingAlgorithms = Object.entries(availableAlgorithms).filter(
+    ([, algo]) => algo.category === "pathfinding"
+  );
+
+  return (
+    <PageLayout
+      title="Pathfinding & Spatial"
+      subtitle="Watch shortest-path search expand cell-by-cell, and see how a heuristic narrows exploration. Edit walls to see the algorithms react."
+    >
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {pathfindingAlgorithms.map((algorithm) => (
+          <AlgorithmCard key={algorithm[0]} algorithm={algorithm[1]} />
+        ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,83 +3,37 @@ import { availableAlgorithms } from "@/lib/algorithms/metadata";
 import { APP_URL } from "@/constants/URL";
 import { glossaryTerms } from "@/lib/glossary/glossary";
 
+type ChangeFreq = MetadataRoute.Sitemap[number]["changeFrequency"];
+
+interface StaticEntry {
+  path: string;
+  changeFrequency: ChangeFreq;
+  priority: number;
+}
+
+const STATIC_ENTRIES: StaticEntry[] = [
+  { path: "", changeFrequency: "weekly", priority: 1.0 },
+  { path: "/about", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/difficulty", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/sorting", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/searching", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/graph", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/datastructure", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/dp", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/pathfinding", changeFrequency: "weekly", priority: 0.9 },
+  { path: "/glossary", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/difficulty/easy", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/difficulty/medium", changeFrequency: "monthly", priority: 0.8 },
+  { path: "/difficulty/hard", changeFrequency: "monthly", priority: 0.8 },
+];
+
 function buildStaticPages(baseUrl: string): MetadataRoute.Sitemap {
-  const monthly = "monthly" as const;
-  const weekly = "weekly" as const;
-  return [
-    {
-      url: baseUrl,
-      lastModified: new Date(),
-      changeFrequency: weekly,
-      priority: 1.0,
-    },
-    {
-      url: `${baseUrl}/about`,
-      lastModified: new Date(),
-      changeFrequency: monthly,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/difficulty`,
-      lastModified: new Date(),
-      changeFrequency: monthly,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/sorting`,
-      lastModified: new Date(),
-      changeFrequency: weekly,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/searching`,
-      lastModified: new Date(),
-      changeFrequency: weekly,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/graph`,
-      lastModified: new Date(),
-      changeFrequency: weekly,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/datastructure`,
-      lastModified: new Date(),
-      changeFrequency: weekly,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/dp`,
-      lastModified: new Date(),
-      changeFrequency: weekly,
-      priority: 0.9,
-    },
-    {
-      url: `${baseUrl}/glossary`,
-      lastModified: new Date(),
-      changeFrequency: monthly,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/difficulty/easy`,
-      lastModified: new Date(),
-      changeFrequency: monthly,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/difficulty/medium`,
-      lastModified: new Date(),
-      changeFrequency: monthly,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/difficulty/hard`,
-      lastModified: new Date(),
-      changeFrequency: monthly,
-      priority: 0.8,
-    },
-  ];
+  return STATIC_ENTRIES.map((entry) => ({
+    url: `${baseUrl}${entry.path}`,
+    lastModified: new Date(),
+    changeFrequency: entry.changeFrequency,
+    priority: entry.priority,
+  }));
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -62,6 +62,7 @@ const navLinks = [
   { href: "/graph", label: "Graph" },
   { href: "/datastructure", label: "Data Structures" },
   { href: "/dp", label: "DP" },
+  { href: "/pathfinding", label: "Pathfinding" },
   { href: "/difficulty", label: "Difficulty" },
   { href: "/glossary", label: "Glossary" },
 ];

--- a/components/primitives/Grid2D.tsx
+++ b/components/primitives/Grid2D.tsx
@@ -14,7 +14,11 @@ interface CellSets {
   visited: Set<string>;
 }
 
-function isCoordEqual(a: GridCoord | null | undefined, row: number, col: number): boolean {
+function isCoordEqual(
+  a: GridCoord | null | undefined,
+  row: number,
+  col: number
+): boolean {
   return !!a && a.row === row && a.col === col;
 }
 

--- a/components/primitives/Grid2D.tsx
+++ b/components/primitives/Grid2D.tsx
@@ -6,21 +6,36 @@ function coordKey(c: GridCoord): string {
   return `${c.row}:${c.col}`;
 }
 
+interface CellSets {
+  highlighted: Set<string>;
+  path: Set<string>;
+  walls: Set<string>;
+  frontier: Set<string>;
+  visited: Set<string>;
+}
+
+function isCoordEqual(a: GridCoord | null | undefined, row: number, col: number): boolean {
+  return !!a && a.row === row && a.col === col;
+}
+
 function cellClasses(
   row: number,
   col: number,
   step: GridStep,
-  highlightedSet: Set<string>,
-  pathSet: Set<string>
+  sets: CellSets
 ): string {
-  const isCurrent =
-    step.current !== null &&
-    step.current.row === row &&
-    step.current.col === col;
   const key = coordKey({ row, col });
-  if (isCurrent) return "bg-yellow-300 border-yellow-500";
-  if (pathSet.has(key)) return "bg-emerald-200 border-emerald-400";
-  if (highlightedSet.has(key)) return "bg-blue-100 border-blue-300";
+  if (sets.walls.has(key)) return "bg-gray-800 border-gray-900";
+  if (isCoordEqual(step.start, row, col))
+    return "bg-green-400 border-green-600 text-white";
+  if (isCoordEqual(step.goal, row, col))
+    return "bg-red-400 border-red-600 text-white";
+  if (isCoordEqual(step.current, row, col))
+    return "bg-yellow-300 border-yellow-500";
+  if (sets.path.has(key)) return "bg-emerald-200 border-emerald-400";
+  if (sets.frontier.has(key)) return "bg-sky-200 border-sky-400";
+  if (sets.visited.has(key)) return "bg-indigo-100 border-indigo-300";
+  if (sets.highlighted.has(key)) return "bg-blue-100 border-blue-300";
   return "bg-white border-gray-200";
 }
 
@@ -29,8 +44,13 @@ interface Grid2DProps {
 }
 
 export default function Grid2D({ step }: Grid2DProps) {
-  const highlightedSet = new Set(step.highlighted.map(coordKey));
-  const pathSet = new Set(step.path.map(coordKey));
+  const sets: CellSets = {
+    highlighted: new Set(step.highlighted.map(coordKey)),
+    path: new Set(step.path.map(coordKey)),
+    walls: new Set((step.walls ?? []).map(coordKey)),
+    frontier: new Set((step.frontier ?? []).map(coordKey)),
+    visited: new Set((step.visited ?? []).map(coordKey)),
+  };
 
   const hasColLabels = step.colLabels.length > 0;
   const hasRowLabels = step.rowLabels.length > 0;
@@ -72,8 +92,7 @@ export default function Grid2D({ step }: Grid2DProps) {
                     rIdx,
                     cIdx,
                     step,
-                    highlightedSet,
-                    pathSet
+                    sets
                   )}`}
                 >
                   {value === null ? "" : value}

--- a/components/visualizer/AlgorithmVisualizer.tsx
+++ b/components/visualizer/AlgorithmVisualizer.tsx
@@ -184,7 +184,7 @@ export default function AlgorithmVisualizer() {
             {renderPrimitive(visualizationData, currentStep)}
           </div>
 
-          {category !== "dp" && (
+          {category !== "dp" && category !== "pathfinding" && (
             <ArrayInputPanel
               category={category}
               numVertices={numVertices}
@@ -205,6 +205,7 @@ export default function AlgorithmVisualizer() {
             isGraphAlgorithm={category === "graph"}
             isTreeAlgorithm={category === "datastructure"}
             isGridAlgorithm={category === "dp"}
+            isPathfindingAlgorithm={category === "pathfinding"}
           />
         </div>
 

--- a/components/visualizer/ColorLegend.tsx
+++ b/components/visualizer/ColorLegend.tsx
@@ -3,6 +3,7 @@ interface ColorLegendProps {
   isGraphAlgorithm?: boolean;
   isTreeAlgorithm?: boolean;
   isGridAlgorithm?: boolean;
+  isPathfindingAlgorithm?: boolean;
 }
 
 interface LegendItem {
@@ -46,7 +47,18 @@ const gridItems: LegendItem[] = [
   { color: "bg-emerald-200", label: "Solution Path" },
 ];
 
+const pathfindingItems: LegendItem[] = [
+  { color: "bg-green-400", label: "Start" },
+  { color: "bg-red-400", label: "Goal" },
+  { color: "bg-gray-800", label: "Wall" },
+  { color: "bg-yellow-300", label: "Current" },
+  { color: "bg-sky-200", label: "Frontier (open set)" },
+  { color: "bg-indigo-100", label: "Visited (closed set)" },
+  { color: "bg-emerald-200", label: "Final Path" },
+];
+
 function pickItems(props: ColorLegendProps): LegendItem[] {
+  if (props.isPathfindingAlgorithm) return pathfindingItems;
   if (props.isSearchAlgorithm) return searchItems;
   if (props.isGraphAlgorithm) return graphItems;
   if (props.isTreeAlgorithm) return treeItems;

--- a/components/visualizer/GridInputPanel.tsx
+++ b/components/visualizer/GridInputPanel.tsx
@@ -28,11 +28,7 @@ function coordKey(c: GridCoord): string {
   return `${c.row}:${c.col}`;
 }
 
-function cellClass(
-  isStart: boolean,
-  isGoal: boolean,
-  isWall: boolean
-): string {
+function cellClass(isStart: boolean, isGoal: boolean, isWall: boolean): string {
   if (isStart) return "bg-green-400 border-green-600";
   if (isGoal) return "bg-red-400 border-red-600";
   if (isWall) return "bg-gray-800 border-gray-900";
@@ -72,7 +68,11 @@ function applyClickInMode(
   return { ...config, walls };
 }
 
-function resize(config: GridConfig, nextRows: number, nextCols: number): GridConfig {
+function resize(
+  config: GridConfig,
+  nextRows: number,
+  nextCols: number
+): GridConfig {
   return {
     rows: nextRows,
     cols: nextCols,
@@ -101,7 +101,7 @@ function ModeToggle({ mode, onChange }: ModeToggleProps) {
         <button
           key={m}
           onClick={() => onChange(m)}
-          className={`rounded px-3 py-1 text-xs font-medium uppercase tracking-wide ${
+          className={`rounded px-3 py-1 text-xs font-medium tracking-wide uppercase ${
             mode === m
               ? "bg-blue-600 text-white"
               : "bg-gray-100 text-gray-700 hover:bg-gray-200"

--- a/components/visualizer/GridInputPanel.tsx
+++ b/components/visualizer/GridInputPanel.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState } from "react";
+import type { GridCoord } from "@/lib/types";
+
+type EditMode = "wall" | "start" | "goal";
+
+interface GridConfig {
+  rows: number;
+  cols: number;
+  start: GridCoord;
+  goal: GridCoord;
+  walls: GridCoord[];
+}
+
+interface GridInputPanelProps {
+  rows: number;
+  cols: number;
+  start: GridCoord;
+  goal: GridCoord;
+  walls: GridCoord[];
+  onChange: (next: GridConfig) => void;
+  onRandomize: () => void;
+  onClearWalls: () => void;
+}
+
+function coordKey(c: GridCoord): string {
+  return `${c.row}:${c.col}`;
+}
+
+function cellClass(
+  isStart: boolean,
+  isGoal: boolean,
+  isWall: boolean
+): string {
+  if (isStart) return "bg-green-400 border-green-600";
+  if (isGoal) return "bg-red-400 border-red-600";
+  if (isWall) return "bg-gray-800 border-gray-900";
+  return "bg-white border-gray-200 hover:bg-gray-50";
+}
+
+function applyClickInMode(
+  mode: EditMode,
+  config: GridConfig,
+  row: number,
+  col: number
+): GridConfig | null {
+  const key = `${row}:${col}`;
+  const startKey = coordKey(config.start);
+  const goalKey = coordKey(config.goal);
+  if (mode === "start") {
+    if (key === goalKey) return null;
+    return {
+      ...config,
+      start: { row, col },
+      walls: config.walls.filter((w) => coordKey(w) !== key),
+    };
+  }
+  if (mode === "goal") {
+    if (key === startKey) return null;
+    return {
+      ...config,
+      goal: { row, col },
+      walls: config.walls.filter((w) => coordKey(w) !== key),
+    };
+  }
+  if (key === startKey || key === goalKey) return null;
+  const wallSet = new Set(config.walls.map(coordKey));
+  const walls = wallSet.has(key)
+    ? config.walls.filter((w) => coordKey(w) !== key)
+    : [...config.walls, { row, col }];
+  return { ...config, walls };
+}
+
+function resize(config: GridConfig, nextRows: number, nextCols: number): GridConfig {
+  return {
+    rows: nextRows,
+    cols: nextCols,
+    start: {
+      row: Math.min(config.start.row, nextRows - 1),
+      col: Math.min(config.start.col, nextCols - 1),
+    },
+    goal: {
+      row: Math.min(config.goal.row, nextRows - 1),
+      col: Math.min(config.goal.col, nextCols - 1),
+    },
+    walls: config.walls.filter((w) => w.row < nextRows && w.col < nextCols),
+  };
+}
+
+interface ModeToggleProps {
+  mode: EditMode;
+  onChange: (m: EditMode) => void;
+}
+
+function ModeToggle({ mode, onChange }: ModeToggleProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-sm">
+      <span className="font-medium text-gray-700">Click to edit:</span>
+      {(["wall", "start", "goal"] as const).map((m) => (
+        <button
+          key={m}
+          onClick={() => onChange(m)}
+          className={`rounded px-3 py-1 text-xs font-medium uppercase tracking-wide ${
+            mode === m
+              ? "bg-blue-600 text-white"
+              : "bg-gray-100 text-gray-700 hover:bg-gray-200"
+          }`}
+        >
+          {m}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+interface SizeInputsProps {
+  rows: number;
+  cols: number;
+  onResize: (rows: number, cols: number) => void;
+}
+
+function SizeInputs({ rows, cols, onResize }: SizeInputsProps) {
+  const onChange = (which: "rows" | "cols", raw: string) => {
+    const v = Number(raw);
+    if (!Number.isFinite(v) || v < 5 || v > 25) return;
+    if (which === "rows") onResize(v, cols);
+    else onResize(rows, v);
+  };
+  return (
+    <div className="flex flex-wrap gap-4 text-sm">
+      <label className="flex items-center gap-2">
+        Rows
+        <input
+          type="number"
+          min={5}
+          max={25}
+          value={rows}
+          onChange={(e) => onChange("rows", e.target.value)}
+          className="w-16 rounded border border-gray-300 px-2 py-1 text-sm"
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        Cols
+        <input
+          type="number"
+          min={5}
+          max={25}
+          value={cols}
+          onChange={(e) => onChange("cols", e.target.value)}
+          className="w-16 rounded border border-gray-300 px-2 py-1 text-sm"
+        />
+      </label>
+    </div>
+  );
+}
+
+interface CellGridProps {
+  rows: number;
+  cols: number;
+  startKey: string;
+  goalKey: string;
+  wallSet: Set<string>;
+  onCellClick: (row: number, col: number) => void;
+}
+
+function CellGrid({
+  rows,
+  cols,
+  startKey,
+  goalKey,
+  wallSet,
+  onCellClick,
+}: CellGridProps) {
+  const cellSize = cols > 12 ? "h-6 w-6" : "h-7 w-7";
+  return (
+    <div className="overflow-x-auto">
+      <div className="inline-block">
+        {Array.from({ length: rows }).map((_, r) => (
+          <div key={r} className="flex">
+            {Array.from({ length: cols }).map((_, c) => {
+              const key = `${r}:${c}`;
+              const cls = cellClass(
+                key === startKey,
+                key === goalKey,
+                wallSet.has(key)
+              );
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => onCellClick(r, c)}
+                  className={`${cellSize} m-0.5 rounded border ${cls} transition-colors`}
+                  aria-label={`Cell ${r},${c}`}
+                />
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function GridInputPanel({
+  rows,
+  cols,
+  start,
+  goal,
+  walls,
+  onChange,
+  onRandomize,
+  onClearWalls,
+}: GridInputPanelProps) {
+  const [mode, setMode] = useState<EditMode>("wall");
+  const config: GridConfig = { rows, cols, start, goal, walls };
+  const startKey = coordKey(start);
+  const goalKey = coordKey(goal);
+  const wallSet = new Set(walls.map(coordKey));
+
+  const handleCellClick = (row: number, col: number) => {
+    const next = applyClickInMode(mode, config, row, col);
+    if (next) onChange(next);
+  };
+
+  const handleResize = (nextRows: number, nextCols: number) => {
+    onChange(resize(config, nextRows, nextCols));
+  };
+
+  return (
+    <div className="card space-y-4 p-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold tracking-wide text-gray-700 uppercase">
+          Grid Editor
+        </h3>
+        <div className="flex gap-2">
+          <button onClick={onRandomize} className="btn btn-secondary text-xs">
+            Randomize
+          </button>
+          <button onClick={onClearWalls} className="btn btn-secondary text-xs">
+            Clear Walls
+          </button>
+        </div>
+      </div>
+      <ModeToggle mode={mode} onChange={setMode} />
+      <SizeInputs rows={rows} cols={cols} onResize={handleResize} />
+      <CellGrid
+        rows={rows}
+        cols={cols}
+        startKey={startKey}
+        goalKey={goalKey}
+        wallSet={wallSet}
+        onCellClick={handleCellClick}
+      />
+    </div>
+  );
+}

--- a/lib/algorithms/index.ts
+++ b/lib/algorithms/index.ts
@@ -18,6 +18,10 @@ import { bstInsert } from "./datastructure/bst";
 import { minHeapInsert } from "./datastructure/heap";
 import { editDistance } from "./dp/editDistance";
 import { lcs } from "./dp/lcs";
+import { aStar } from "./pathfinding/aStar";
+import { dijkstraGrid } from "./pathfinding/dijkstraGrid";
+import { mazeRecursiveBacktracker } from "./pathfinding/mazeRecursiveBacktracker";
+import type { PathfindingInput } from "./pathfinding/grid";
 
 export type SortingFn = (array: number[]) => AlgorithmVisualization;
 export type SearchFn = (
@@ -30,6 +34,9 @@ export type GraphFn = (
 ) => AlgorithmVisualization;
 export type DataStructureFn = (values: number[]) => AlgorithmVisualization;
 export type DpFn = (a: string, b: string) => AlgorithmVisualization;
+export type PathfindingFn = (
+  input: PathfindingInput
+) => AlgorithmVisualization;
 
 const sortingAlgorithms = {
   bubbleSort,
@@ -65,17 +72,25 @@ const dpAlgorithms = {
   lcs,
 } as const satisfies Record<string, DpFn>;
 
+const pathfindingAlgorithms = {
+  aStar,
+  dijkstraGrid,
+  mazeRecursiveBacktracker,
+} as const satisfies Record<string, PathfindingFn>;
+
 export type SortingAlgorithmName = keyof typeof sortingAlgorithms;
 export type SearchAlgorithmName = keyof typeof searchAlgorithms;
 export type GraphAlgorithmName = keyof typeof graphAlgorithms;
 export type DataStructureAlgorithmName = keyof typeof dataStructureAlgorithms;
 export type DpAlgorithmName = keyof typeof dpAlgorithms;
+export type PathfindingAlgorithmName = keyof typeof pathfindingAlgorithms;
 export type AlgorithmName =
   | SortingAlgorithmName
   | SearchAlgorithmName
   | GraphAlgorithmName
   | DataStructureAlgorithmName
-  | DpAlgorithmName;
+  | DpAlgorithmName
+  | PathfindingAlgorithmName;
 
 export function isSortingAlgorithm(name: string): name is SortingAlgorithmName {
   return name in sortingAlgorithms;
@@ -99,13 +114,20 @@ export function isDpAlgorithm(name: string): name is DpAlgorithmName {
   return name in dpAlgorithms;
 }
 
+export function isPathfindingAlgorithm(
+  name: string
+): name is PathfindingAlgorithmName {
+  return name in pathfindingAlgorithms;
+}
+
 export function isAlgorithmName(name: string): name is AlgorithmName {
   return (
     isSortingAlgorithm(name) ||
     isSearchAlgorithm(name) ||
     isGraphAlgorithm(name) ||
     isDataStructureAlgorithm(name) ||
-    isDpAlgorithm(name)
+    isDpAlgorithm(name) ||
+    isPathfindingAlgorithm(name)
   );
 }
 
@@ -131,6 +153,10 @@ export function getDpAlgorithm(name: string): DpFn | null {
   return isDpAlgorithm(name) ? dpAlgorithms[name] : null;
 }
 
+export function getPathfindingAlgorithm(name: string): PathfindingFn | null {
+  return isPathfindingAlgorithm(name) ? pathfindingAlgorithms[name] : null;
+}
+
 export {
   bubbleSort,
   selectionSort,
@@ -151,4 +177,7 @@ export {
   minHeapInsert,
   editDistance,
   lcs,
+  aStar,
+  dijkstraGrid,
+  mazeRecursiveBacktracker,
 };

--- a/lib/algorithms/index.ts
+++ b/lib/algorithms/index.ts
@@ -34,9 +34,7 @@ export type GraphFn = (
 ) => AlgorithmVisualization;
 export type DataStructureFn = (values: number[]) => AlgorithmVisualization;
 export type DpFn = (a: string, b: string) => AlgorithmVisualization;
-export type PathfindingFn = (
-  input: PathfindingInput
-) => AlgorithmVisualization;
+export type PathfindingFn = (input: PathfindingInput) => AlgorithmVisualization;
 
 const sortingAlgorithms = {
   bubbleSort,

--- a/lib/algorithms/metadata.ts
+++ b/lib/algorithms/metadata.ts
@@ -177,4 +177,31 @@ export const availableAlgorithms: Record<string, AlgorithmInfo> = {
       "The longest common subsequence (LCS) of two sequences is the longest sequence appearing in both as a subsequence — preserving order but not contiguity. The standard dynamic-programming solution fills an (m+1)×(n+1) table where dp[i][j] is the LCS length of the first i and j characters. When characters match, the cell extends the diagonal by one; otherwise it inherits the larger of its top and left neighbours. The table fills in O(m·n), and a traceback recovers the actual subsequence. LCS is the workhorse behind Unix `diff`, version control merge, and computational biology sequence alignment.",
     difficulty: "medium",
   },
+  aStar: {
+    name: "A* Pathfinding",
+    key: "aStar",
+    category: "pathfinding",
+    subtitle: "Best-first search guided by a heuristic to a goal cell",
+    description:
+      "A* finds the shortest path from a start cell to a goal cell on a grid by combining the cost so far (g) with an admissible estimate of the remaining cost (h, here Manhattan distance). It always expands the open-set node with the smallest f = g + h, which lets it focus exploration toward the goal rather than fanning out uniformly like Dijkstra's. With an admissible, consistent heuristic, A* is guaranteed to return an optimal path, and it routinely outperforms uninformed search on spatial maps. Pathfinding in games, robotics, and routing systems is the canonical application.",
+    difficulty: "medium",
+  },
+  dijkstraGrid: {
+    name: "Dijkstra (Grid)",
+    key: "dijkstraGrid",
+    category: "pathfinding",
+    subtitle: "Uniform-cost shortest path on a grid with obstacles",
+    description:
+      "Dijkstra's algorithm specialised to a grid finds the shortest path from a start cell to a goal cell when every step costs the same. It expands the open-set node with the smallest tentative distance, relaxing each unblocked neighbour, until it pops the goal. Unlike A*, it has no heuristic — every direction is treated equally — so it explores the frontier as an expanding ring around the start. The grid version makes the difference from heuristic-guided search tangible: side-by-side with A*, you see exactly how much exploration the heuristic saves.",
+    difficulty: "medium",
+  },
+  mazeRecursiveBacktracker: {
+    name: "Recursive Backtracker (Maze)",
+    key: "mazeRecursiveBacktracker",
+    category: "pathfinding",
+    subtitle: "Carve a perfect maze with randomised depth-first search",
+    description:
+      "The recursive backtracker — also called randomised depth-first search — generates a perfect maze (one with exactly one path between any two cells) by carving passages from a starting cell. At each step it picks a random unvisited neighbour two cells away, knocks down the wall between them, and recurses; when no unvisited neighbours remain, it backtracks. The result is a long, winding maze with few short branches, distinct from algorithms like Prim's or Wilson's that produce more uniform structure. Mazes generated this way are a common test bed for pathfinding algorithms.",
+    difficulty: "medium",
+  },
 };

--- a/lib/algorithms/pathfinding/aStar.ts
+++ b/lib/algorithms/pathfinding/aStar.ts
@@ -1,4 +1,9 @@
-import type { AlgorithmVisualization, GridCell, GridCoord, GridStep } from "../../types";
+import type {
+  AlgorithmVisualization,
+  GridCell,
+  GridCoord,
+  GridStep,
+} from "../../types";
 import { createVisualization } from "../utils";
 import {
   coordFromKey,

--- a/lib/algorithms/pathfinding/aStar.ts
+++ b/lib/algorithms/pathfinding/aStar.ts
@@ -1,0 +1,207 @@
+import type { AlgorithmVisualization, GridCell, GridCoord, GridStep } from "../../types";
+import { createVisualization } from "../utils";
+import {
+  coordFromKey,
+  coordKey,
+  inBounds,
+  manhattan,
+  neighborMessage,
+  neighbors4,
+  popLowestKey,
+  type PathfindingInput,
+} from "./grid";
+
+const PSEUDO = [
+  "procedure aStar(start, goal, walls)",
+  "  open := { start }",
+  "  g[start] := 0; f[start] := h(start, goal)",
+  "  while open is not empty do",
+  "    current := node in open with lowest f",
+  "    if current = goal then return reconstruct(current)",
+  "    remove current from open; mark closed",
+  "    for each neighbor n of current do",
+  "      if n is wall or closed: continue",
+  "      tentative := g[current] + 1",
+  "      if tentative < g[n] then",
+  "        cameFrom[n] := current",
+  "        g[n] := tentative; f[n] := tentative + h(n, goal)",
+  "        add n to open",
+  "  return failure",
+];
+
+const DETAILS = {
+  timeComplexity: "O((V + E) log V)",
+  spaceComplexity: "O(V)",
+  reference: "https://en.wikipedia.org/wiki/A*_search_algorithm",
+  pseudoCode: PSEUDO,
+};
+
+interface CellCost {
+  g: number;
+  f: number;
+}
+
+interface State {
+  input: PathfindingInput;
+  wallSet: Set<string>;
+  open: Set<string>;
+  closed: Set<string>;
+  cost: Map<string, CellCost>;
+  cameFrom: Map<string, GridCoord>;
+}
+
+function emptyGrid(rows: number, cols: number): GridCell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => null as GridCell)
+  );
+}
+
+function snapshotCells(
+  rows: number,
+  cols: number,
+  cost: Map<string, CellCost>
+): GridCell[][] {
+  const grid = emptyGrid(rows, cols);
+  for (const [key, c] of cost) {
+    const { row, col } = coordFromKey(key);
+    grid[row]![col] = Number.isFinite(c.f) ? c.f : null;
+  }
+  return grid;
+}
+
+function reconstructPath(
+  cameFrom: Map<string, GridCoord>,
+  goal: GridCoord
+): GridCoord[] {
+  const path: GridCoord[] = [];
+  let cur: GridCoord | undefined = goal;
+  while (cur) {
+    path.push(cur);
+    cur = cameFrom.get(coordKey(cur));
+  }
+  return path.reverse();
+}
+
+function pushStep(
+  steps: GridStep[],
+  state: State,
+  partial: {
+    current: GridCoord | null;
+    path?: GridCoord[];
+    highlighted?: GridCoord[];
+    message: string;
+    lineNumber: number;
+  }
+): void {
+  const { input, cost, open, closed } = state;
+  steps.push({
+    rows: input.rows,
+    cols: input.cols,
+    cells: snapshotCells(input.rows, input.cols, cost),
+    rowLabels: [],
+    colLabels: [],
+    current: partial.current,
+    highlighted: partial.highlighted ?? [],
+    path: partial.path ?? [],
+    walls: input.walls.map((w) => ({ ...w })),
+    start: { ...input.start },
+    goal: { ...input.goal },
+    frontier: [...open].map(coordFromKey),
+    visited: [...closed].map(coordFromKey),
+    message: partial.message,
+    lineNumber: partial.lineNumber,
+  });
+}
+
+function relaxNeighbors(
+  state: State,
+  current: GridCoord,
+  bestKey: string
+): GridCoord[] {
+  const { input, wallSet, closed, cost, cameFrom, open } = state;
+  const expandable: GridCoord[] = [];
+  const baseG = cost.get(bestKey)?.g ?? Infinity;
+  for (const n of neighbors4(current)) {
+    if (!inBounds(input.rows, input.cols, n)) continue;
+    const nKey = coordKey(n);
+    if (wallSet.has(nKey) || closed.has(nKey)) continue;
+    const tentativeG = baseG + 1;
+    const existing = cost.get(nKey);
+    if (existing && tentativeG >= existing.g) continue;
+    cameFrom.set(nKey, current);
+    cost.set(nKey, { g: tentativeG, f: tentativeG + manhattan(n, input.goal) });
+    open.add(nKey);
+    expandable.push(n);
+  }
+  return expandable;
+}
+
+function isGoal(c: GridCoord, goal: GridCoord): boolean {
+  return c.row === goal.row && c.col === goal.col;
+}
+
+export function aStar(input: PathfindingInput): AlgorithmVisualization {
+  const { start, goal, walls } = input;
+  const state: State = {
+    input,
+    wallSet: new Set(walls.map(coordKey)),
+    open: new Set<string>([coordKey(start)]),
+    closed: new Set<string>(),
+    cost: new Map<string, CellCost>([
+      [coordKey(start), { g: 0, f: manhattan(start, goal) }],
+    ]),
+    cameFrom: new Map<string, GridCoord>(),
+  };
+
+  const steps: GridStep[] = [];
+  pushStep(steps, state, {
+    current: null,
+    message: `A* from (${start.row},${start.col}) to (${goal.row},${goal.col}).`,
+    lineNumber: 1,
+  });
+
+  while (state.open.size > 0) {
+    const bestKey = popLowestKey(
+      state.open,
+      (k) => state.cost.get(k)?.f ?? Infinity
+    );
+    if (bestKey === null) break;
+    const current = coordFromKey(bestKey);
+    const bestF = state.cost.get(bestKey)?.f ?? Infinity;
+
+    pushStep(steps, state, {
+      current,
+      message: `Pop (${current.row},${current.col}) — lowest f = ${bestF}.`,
+      lineNumber: 4,
+    });
+
+    if (isGoal(current, goal)) {
+      const path = reconstructPath(state.cameFrom, goal);
+      pushStep(steps, state, {
+        current,
+        path,
+        message: `Reached goal — path length ${path.length - 1}.`,
+        lineNumber: 5,
+      });
+      return createVisualization("aStar", "grid-2d", steps, DETAILS);
+    }
+
+    state.open.delete(bestKey);
+    state.closed.add(bestKey);
+    const expandable = relaxNeighbors(state, current, bestKey);
+
+    pushStep(steps, state, {
+      current,
+      highlighted: expandable,
+      message: neighborMessage(current, expandable.length),
+      lineNumber: 7,
+    });
+  }
+
+  pushStep(steps, state, {
+    current: null,
+    message: "Open set exhausted — no path exists.",
+    lineNumber: 14,
+  });
+  return createVisualization("aStar", "grid-2d", steps, DETAILS);
+}

--- a/lib/algorithms/pathfinding/dijkstraGrid.ts
+++ b/lib/algorithms/pathfinding/dijkstraGrid.ts
@@ -1,0 +1,198 @@
+import type { AlgorithmVisualization, GridCell, GridCoord, GridStep } from "../../types";
+import { createVisualization } from "../utils";
+import {
+  coordFromKey,
+  coordKey,
+  inBounds,
+  neighborMessage,
+  neighbors4,
+  popLowestKey,
+  type PathfindingInput,
+} from "./grid";
+
+const PSEUDO = [
+  "procedure dijkstra(start, goal, walls)",
+  "  dist[start] := 0; dist[v] := ∞ for all other v",
+  "  open := { start }",
+  "  while open is not empty do",
+  "    current := node in open with smallest dist",
+  "    if current = goal then return reconstruct(current)",
+  "    remove current from open; mark visited",
+  "    for each neighbor n of current do",
+  "      if n is wall or visited: continue",
+  "      alt := dist[current] + 1",
+  "      if alt < dist[n] then",
+  "        dist[n] := alt; cameFrom[n] := current",
+  "        add n to open",
+  "  return failure",
+];
+
+const DETAILS = {
+  timeComplexity: "O((V + E) log V)",
+  spaceComplexity: "O(V)",
+  reference: "https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm",
+  pseudoCode: PSEUDO,
+};
+
+interface State {
+  input: PathfindingInput;
+  wallSet: Set<string>;
+  open: Set<string>;
+  closed: Set<string>;
+  dist: Map<string, number>;
+  cameFrom: Map<string, GridCoord>;
+}
+
+function emptyGrid(rows: number, cols: number): GridCell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => null as GridCell)
+  );
+}
+
+function snapshotCells(
+  rows: number,
+  cols: number,
+  dist: Map<string, number>
+): GridCell[][] {
+  const grid = emptyGrid(rows, cols);
+  for (const [key, d] of dist) {
+    if (!Number.isFinite(d)) continue;
+    const { row, col } = coordFromKey(key);
+    grid[row]![col] = d;
+  }
+  return grid;
+}
+
+function reconstructPath(
+  cameFrom: Map<string, GridCoord>,
+  goal: GridCoord
+): GridCoord[] {
+  const path: GridCoord[] = [];
+  let cur: GridCoord | undefined = goal;
+  while (cur) {
+    path.push(cur);
+    cur = cameFrom.get(coordKey(cur));
+  }
+  return path.reverse();
+}
+
+function pushStep(
+  steps: GridStep[],
+  state: State,
+  partial: {
+    current: GridCoord | null;
+    path?: GridCoord[];
+    highlighted?: GridCoord[];
+    message: string;
+    lineNumber: number;
+  }
+): void {
+  const { input, dist, open, closed } = state;
+  steps.push({
+    rows: input.rows,
+    cols: input.cols,
+    cells: snapshotCells(input.rows, input.cols, dist),
+    rowLabels: [],
+    colLabels: [],
+    current: partial.current,
+    highlighted: partial.highlighted ?? [],
+    path: partial.path ?? [],
+    walls: input.walls.map((w) => ({ ...w })),
+    start: { ...input.start },
+    goal: { ...input.goal },
+    frontier: [...open].map(coordFromKey),
+    visited: [...closed].map(coordFromKey),
+    message: partial.message,
+    lineNumber: partial.lineNumber,
+  });
+}
+
+function relaxNeighbors(
+  state: State,
+  current: GridCoord,
+  bestKey: string
+): GridCoord[] {
+  const { input, wallSet, closed, dist, cameFrom, open } = state;
+  const relaxed: GridCoord[] = [];
+  const baseDist = dist.get(bestKey) ?? Infinity;
+  for (const n of neighbors4(current)) {
+    if (!inBounds(input.rows, input.cols, n)) continue;
+    const nKey = coordKey(n);
+    if (wallSet.has(nKey) || closed.has(nKey)) continue;
+    const alt = baseDist + 1;
+    if (alt >= (dist.get(nKey) ?? Infinity)) continue;
+    dist.set(nKey, alt);
+    cameFrom.set(nKey, current);
+    open.add(nKey);
+    relaxed.push(n);
+  }
+  return relaxed;
+}
+
+function isGoal(c: GridCoord, goal: GridCoord): boolean {
+  return c.row === goal.row && c.col === goal.col;
+}
+
+export function dijkstraGrid(input: PathfindingInput): AlgorithmVisualization {
+  const { start, goal, walls } = input;
+  const state: State = {
+    input,
+    wallSet: new Set(walls.map(coordKey)),
+    open: new Set<string>([coordKey(start)]),
+    closed: new Set<string>(),
+    dist: new Map<string, number>([[coordKey(start), 0]]),
+    cameFrom: new Map<string, GridCoord>(),
+  };
+
+  const steps: GridStep[] = [];
+  pushStep(steps, state, {
+    current: null,
+    message: `Dijkstra from (${start.row},${start.col}) to (${goal.row},${goal.col}).`,
+    lineNumber: 1,
+  });
+
+  while (state.open.size > 0) {
+    const bestKey = popLowestKey(
+      state.open,
+      (k) => state.dist.get(k) ?? Infinity
+    );
+    if (bestKey === null) break;
+    const current = coordFromKey(bestKey);
+    const bestDist = state.dist.get(bestKey) ?? Infinity;
+
+    pushStep(steps, state, {
+      current,
+      message: `Pop (${current.row},${current.col}) — distance ${bestDist}.`,
+      lineNumber: 4,
+    });
+
+    if (isGoal(current, goal)) {
+      const path = reconstructPath(state.cameFrom, goal);
+      pushStep(steps, state, {
+        current,
+        path,
+        message: `Reached goal — shortest distance is ${bestDist}.`,
+        lineNumber: 5,
+      });
+      return createVisualization("dijkstraGrid", "grid-2d", steps, DETAILS);
+    }
+
+    state.open.delete(bestKey);
+    state.closed.add(bestKey);
+    const relaxed = relaxNeighbors(state, current, bestKey);
+
+    pushStep(steps, state, {
+      current,
+      highlighted: relaxed,
+      message: neighborMessage(current, relaxed.length),
+      lineNumber: 7,
+    });
+  }
+
+  pushStep(steps, state, {
+    current: null,
+    message: "Open set exhausted — goal unreachable.",
+    lineNumber: 14,
+  });
+  return createVisualization("dijkstraGrid", "grid-2d", steps, DETAILS);
+}

--- a/lib/algorithms/pathfinding/dijkstraGrid.ts
+++ b/lib/algorithms/pathfinding/dijkstraGrid.ts
@@ -1,4 +1,9 @@
-import type { AlgorithmVisualization, GridCell, GridCoord, GridStep } from "../../types";
+import type {
+  AlgorithmVisualization,
+  GridCell,
+  GridCoord,
+  GridStep,
+} from "../../types";
 import { createVisualization } from "../utils";
 import {
   coordFromKey,

--- a/lib/algorithms/pathfinding/grid.ts
+++ b/lib/algorithms/pathfinding/grid.ts
@@ -1,0 +1,70 @@
+import type { GridCoord } from "../../types";
+
+export interface PathfindingInput {
+  rows: number;
+  cols: number;
+  start: GridCoord;
+  goal: GridCoord;
+  walls: GridCoord[];
+}
+
+export function coordKey(c: GridCoord): string {
+  return `${c.row}:${c.col}`;
+}
+
+export function inBounds(rows: number, cols: number, c: GridCoord): boolean {
+  return c.row >= 0 && c.row < rows && c.col >= 0 && c.col < cols;
+}
+
+export function neighbors4(c: GridCoord): GridCoord[] {
+  return [
+    { row: c.row - 1, col: c.col },
+    { row: c.row + 1, col: c.col },
+    { row: c.row, col: c.col - 1 },
+    { row: c.row, col: c.col + 1 },
+  ];
+}
+
+export function manhattan(a: GridCoord, b: GridCoord): number {
+  return Math.abs(a.row - b.row) + Math.abs(a.col - b.col);
+}
+
+export function clampCoord(
+  rows: number,
+  cols: number,
+  c: GridCoord
+): GridCoord {
+  return {
+    row: Math.max(0, Math.min(rows - 1, c.row)),
+    col: Math.max(0, Math.min(cols - 1, c.col)),
+  };
+}
+
+export function coordFromKey(key: string): GridCoord {
+  const [r, c] = key.split(":");
+  return { row: Number(r), col: Number(c) };
+}
+
+export function neighborMessage(current: GridCoord, count: number): string {
+  if (count === 0) {
+    return `No neighbors of (${current.row},${current.col}) to relax.`;
+  }
+  const plural = count === 1 ? "" : "s";
+  return `Relaxed ${count} neighbor${plural} of (${current.row},${current.col}).`;
+}
+
+export function popLowestKey(
+  keys: Set<string>,
+  scoreOf: (key: string) => number
+): string | null {
+  let best: string | null = null;
+  let bestScore = Infinity;
+  for (const k of keys) {
+    const s = scoreOf(k);
+    if (s < bestScore) {
+      bestScore = s;
+      best = k;
+    }
+  }
+  return best;
+}

--- a/lib/algorithms/pathfinding/mazeRecursiveBacktracker.ts
+++ b/lib/algorithms/pathfinding/mazeRecursiveBacktracker.ts
@@ -1,4 +1,9 @@
-import type { AlgorithmVisualization, GridCell, GridCoord, GridStep } from "../../types";
+import type {
+  AlgorithmVisualization,
+  GridCell,
+  GridCoord,
+  GridStep,
+} from "../../types";
 import { createVisualization } from "../utils";
 import { coordKey, type PathfindingInput } from "./grid";
 
@@ -107,8 +112,14 @@ function unvisitedNeighbors(
 }
 
 function snapStartCell(input: PathfindingInput): GridCoord {
-  const r = input.start.row % 2 === 1 ? input.start.row : Math.max(1, input.start.row - 1);
-  const c = input.start.col % 2 === 1 ? input.start.col : Math.max(1, input.start.col - 1);
+  const r =
+    input.start.row % 2 === 1
+      ? input.start.row
+      : Math.max(1, input.start.row - 1);
+  const c =
+    input.start.col % 2 === 1
+      ? input.start.col
+      : Math.max(1, input.start.col - 1);
   return {
     row: Math.min(r, input.rows - 2),
     col: Math.min(c, input.cols - 2),

--- a/lib/algorithms/pathfinding/mazeRecursiveBacktracker.ts
+++ b/lib/algorithms/pathfinding/mazeRecursiveBacktracker.ts
@@ -1,0 +1,197 @@
+import type { AlgorithmVisualization, GridCell, GridCoord, GridStep } from "../../types";
+import { createVisualization } from "../utils";
+import { coordKey, type PathfindingInput } from "./grid";
+
+const PSEUDO = [
+  "procedure recursiveBacktracker(grid)",
+  "  mark every cell as wall",
+  "  push start onto stack; carve start",
+  "  while stack is not empty do",
+  "    current := top of stack",
+  "    candidates := neighbors 2 cells away that are still walls",
+  "    if candidates is empty then",
+  "      pop stack (backtrack)",
+  "    else",
+  "      pick random candidate n",
+  "      carve cell between current and n",
+  "      carve n; push n",
+];
+
+function emptyCells(rows: number, cols: number): GridCell[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => null as GridCell)
+  );
+}
+
+function listWalls(
+  isWall: boolean[][],
+  rows: number,
+  cols: number
+): GridCoord[] {
+  const out: GridCoord[] = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      if (isWall[r]![c]) out.push({ row: r, col: c });
+    }
+  }
+  return out;
+}
+
+interface BuildArgs {
+  input: PathfindingInput;
+  isWall: boolean[][];
+  carved: Set<string>;
+  stack: GridCoord[];
+  rng: () => number;
+}
+
+function pushStep(
+  steps: GridStep[],
+  args: BuildArgs,
+  partial: {
+    current: GridCoord | null;
+    highlighted?: GridCoord[];
+    message: string;
+    lineNumber: number;
+  }
+): void {
+  const { input, isWall, carved, stack } = args;
+  const visited: GridCoord[] = [];
+  for (const k of carved) {
+    const [r, c] = k.split(":");
+    visited.push({ row: Number(r), col: Number(c) });
+  }
+  const frontier: GridCoord[] = stack.map((c) => ({ ...c }));
+  steps.push({
+    rows: input.rows,
+    cols: input.cols,
+    cells: emptyCells(input.rows, input.cols),
+    rowLabels: [],
+    colLabels: [],
+    current: partial.current,
+    highlighted: partial.highlighted ?? [],
+    path: [],
+    walls: listWalls(isWall, input.rows, input.cols),
+    start: null,
+    goal: null,
+    frontier,
+    visited,
+    message: partial.message,
+    lineNumber: partial.lineNumber,
+  });
+}
+
+function unvisitedNeighbors(
+  cell: GridCoord,
+  isWall: boolean[][],
+  rows: number,
+  cols: number
+): { neighbor: GridCoord; between: GridCoord }[] {
+  const offsets = [
+    { dr: -2, dc: 0 },
+    { dr: 2, dc: 0 },
+    { dr: 0, dc: -2 },
+    { dr: 0, dc: 2 },
+  ];
+  const out: { neighbor: GridCoord; between: GridCoord }[] = [];
+  for (const o of offsets) {
+    const n = { row: cell.row + o.dr, col: cell.col + o.dc };
+    if (n.row <= 0 || n.row >= rows - 1 || n.col <= 0 || n.col >= cols - 1) {
+      continue;
+    }
+    if (!isWall[n.row]![n.col]) continue;
+    const between = { row: cell.row + o.dr / 2, col: cell.col + o.dc / 2 };
+    out.push({ neighbor: n, between });
+  }
+  return out;
+}
+
+function snapStartCell(input: PathfindingInput): GridCoord {
+  const r = input.start.row % 2 === 1 ? input.start.row : Math.max(1, input.start.row - 1);
+  const c = input.start.col % 2 === 1 ? input.start.col : Math.max(1, input.start.col - 1);
+  return {
+    row: Math.min(r, input.rows - 2),
+    col: Math.min(c, input.cols - 2),
+  };
+}
+
+export function mazeRecursiveBacktracker(
+  input: PathfindingInput
+): AlgorithmVisualization {
+  const { rows, cols } = input;
+  const isWall: boolean[][] = Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => true)
+  );
+  const carved = new Set<string>();
+  const stack: GridCoord[] = [];
+  const rng = mulberry32(0x9e3779b9);
+  const args: BuildArgs = { input, isWall, carved, stack, rng };
+
+  const steps: GridStep[] = [];
+  pushStep(steps, args, {
+    current: null,
+    message: `Initialize: every cell is a wall on a ${rows}×${cols} grid.`,
+    lineNumber: 1,
+  });
+
+  const startCell = snapStartCell(input);
+  isWall[startCell.row]![startCell.col] = false;
+  carved.add(coordKey(startCell));
+  stack.push(startCell);
+  pushStep(steps, args, {
+    current: startCell,
+    message: `Carve start at (${startCell.row},${startCell.col}).`,
+    lineNumber: 2,
+  });
+
+  while (stack.length > 0) {
+    const current = stack[stack.length - 1]!;
+    const candidates = unvisitedNeighbors(current, isWall, rows, cols);
+    if (candidates.length === 0) {
+      stack.pop();
+      pushStep(steps, args, {
+        current,
+        message: `Backtrack from (${current.row},${current.col}) — no walled neighbors.`,
+        lineNumber: 7,
+      });
+      continue;
+    }
+    const pick = candidates[Math.floor(rng() * candidates.length)]!;
+    isWall[pick.between.row]![pick.between.col] = false;
+    isWall[pick.neighbor.row]![pick.neighbor.col] = false;
+    carved.add(coordKey(pick.between));
+    carved.add(coordKey(pick.neighbor));
+    stack.push(pick.neighbor);
+    pushStep(steps, args, {
+      current: pick.neighbor,
+      highlighted: [pick.between],
+      message: `Carve (${pick.between.row},${pick.between.col}) → (${pick.neighbor.row},${pick.neighbor.col}).`,
+      lineNumber: 11,
+    });
+  }
+
+  pushStep(steps, args, {
+    current: null,
+    message: `Maze complete — ${carved.size} cells carved.`,
+    lineNumber: 0,
+  });
+
+  return createVisualization("mazeRecursiveBacktracker", "grid-2d", steps, {
+    timeComplexity: "O(rows × cols)",
+    spaceComplexity: "O(rows × cols)",
+    reference:
+      "https://en.wikipedia.org/wiki/Maze_generation_algorithm#Randomized_depth-first_search",
+    pseudoCode: PSEUDO,
+  });
+}
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -73,6 +73,11 @@ export interface GridStep {
   rowLabels: string[];
   colLabels: string[];
   message: string;
+  walls?: GridCoord[];
+  start?: GridCoord | null;
+  goal?: GridCoord | null;
+  frontier?: GridCoord[];
+  visited?: GridCoord[];
   lineNumber?: number;
 }
 
@@ -119,7 +124,8 @@ export type AlgorithmCategory =
   | "searching"
   | "graph"
   | "datastructure"
-  | "dp";
+  | "dp"
+  | "pathfinding";
 
 export interface AlgorithmInfo {
   name: string;


### PR DESCRIPTION
## Summary

Phase 8 of the project-vision roadmap: pathfinding & spatial algorithms on the existing `Grid2D` primitive. Adds three new algorithms — **A\***, **Dijkstra-on-grid**, and **recursive-backtracker maze generation** — under a new `pathfinding` category, with a click-to-edit grid input panel and URL-shareable grid configuration.

## What changed

- **Type extension.** `GridStep` gains optional `walls`, `start`, `goal`, `frontier`, and `visited` fields. DP code is unchanged — it just doesn't populate them.
- **`Grid2D` renderer** now draws walls (gray), start (green), goal (red), frontier / open set (sky), visited / closed set (indigo), current (yellow), and final path (emerald).
- **New algorithms** in `lib/algorithms/pathfinding/`:
  - `aStar.ts` — Manhattan-heuristic best-first search (admissible & consistent on a 4-connected unit-cost grid)
  - `dijkstraGrid.ts` — uniform-cost shortest path on a grid
  - `mazeRecursiveBacktracker.ts` — randomised DFS maze gen; uses a seeded Mulberry32 PRNG so visualizations are reproducible across reloads
  - `grid.ts` — shared helpers (`coordKey`, `coordFromKey`, `neighbors4`, `manhattan`, `popLowestKey`, `neighborMessage`, `inBounds`)
- **Registry.** New `pathfinding` `AlgorithmCategory`, `PathfindingFn` signature `(input: PathfindingInput) => AlgorithmVisualization`, plus `getPathfindingAlgorithm` / `isPathfindingAlgorithm` guards.
- **Routes.** `/pathfinding` (category landing) and `/pathfinding/[algorithm]` (visualizer). Grid config is URL-encoded as `?r=N&c=M&s=row,col&g=row,col&w=r,c;r,c;…`.
- **`GridInputPanel`** — click-to-edit grid with three modes (wall / start / goal), resize controls (5–25), randomize/clear-walls buttons. Resize clamps walls/start/goal into the new bounds.
- **Wiring.** Navbar link, sitemap entries, home page category map, `ColorLegend` palette, and `AlgorithmVisualizer` skips `ArrayInputPanel` for pathfinding (similar to DP).
- **Tests.** New `__tests__/lib/algorithms/pathfinding/pathfinding.test.ts` covers A\* / Dijkstra optimality, wall routing, unreachable goals, start=goal, and maze invariants (carved ∩ walls = ∅). Registry test extended for the new helpers. **176 tests, all green.**
- **Refactor of `app/sitemap.ts`** to a data-driven static-entries list (the per-route block was about to push the function past the 80-line cap).
- **`GROWTH.md`** — Phase 8 snapshot prepended.

## Why

Per the multi-phase project vision, Phase 8 opens the spatial / pathfinding domain. A\* is intentionally folded in here (rather than added to `Graph2D`) because its natural home is a grid with editable obstacles. The shared `Grid2D` primitive means we got three new algorithms with one renderer extension and no new primitive.

## Reviewer notes

- **Maze gen is deterministic.** The Mulberry32 seed is fixed at `0x9e3779b9`, so the maze regenerates identically on every load. To re-randomize on demand, the route would need to thread a fresh seed — left for a follow-up since the visual point is "watch the carve," and reproducibility is more useful than novelty here.
- **`PathfindingFn` shape.** Maze generation accepts the same `PathfindingInput` as the search algorithms; it ignores `walls` (it produces them) but uses `start` to seed the carve. Consistent signature is worth the unused field.
- **A\* heuristic.** Manhattan distance only — admissible and consistent on a 4-connected grid with unit edge costs, which is the configuration we expose. If we ever add diagonal moves or non-unit costs, this would need to change.
- **`GridStep` field shape.** All five new fields are optional. DP renderers / step builders are untouched. If a future caller forgets to populate them, the renderer falls back to empty sets.

## Test plan

- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 176 / 176 passing
- [x] `npm run build` — passes; `/pathfinding` static, `/pathfinding/[algorithm]` dynamic
- [ ] Manual: visit `/pathfinding/aStar`, edit walls and watch the path re-route; confirm URL stays in sync; reload to confirm restoration
- [ ] Manual: side-by-side compare `/pathfinding/aStar` vs `/pathfinding/dijkstraGrid` on the same wall layout — A\* should visit fewer cells
- [ ] Manual: visit `/pathfinding/mazeRecursiveBacktracker` and confirm a clean maze renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)
